### PR TITLE
fixed equip and loadGame crash

### DIFF
--- a/creature.cpp
+++ b/creature.cpp
@@ -579,7 +579,7 @@ bool Creature::canEquipIfEmptySlot(const Item* item, string* reason) const {
 }
 
 bool Creature::canEquip(const Item* item) const {
-  return !equipment.getItem(item->getEquipmentSlot()) && canEquipIfEmptySlot(item, nullptr);
+  return canEquipIfEmptySlot(item, nullptr) && !equipment.getItem(item->getEquipmentSlot());
 }
 
 Creature::Action Creature::equip(Item* item) {

--- a/main.cpp
+++ b/main.cpp
@@ -117,6 +117,9 @@ static unique_ptr<Model> loadGame(const string& filename, bool eraseFile) {
     boost::archive::binary_iarchive ia(in);
     Serialization::registerTypes(ia);
     ia >> BOOST_SERIALIZATION_NVP(model);
+
+    Skill::clearAll();
+    Skill::init();
   }
 #ifdef RELEASE
   if (eraseFile && !Options::getValue(OptionId::KEEP_SAVEFILES))


### PR DESCRIPTION
Fixed some things that crashed my game.
The item->getEquipmentSlot() throws an exception saying that canEquip() is false. After things had been made in the workshop and a creature tried to pick them up it would throw out the exception. The order the of the function calls seems to matter because of the short-circuit evaluation of &&.
When loading a save file I got a segmentation fault because in Creature::hasSkill(Skill\* skill), skill->getId() returns some uninitialized value which is outside the bounds of skills. Re-initializing Skill seems to fix this. 
