### PR TITLE
Fix Boost 1.56 array serialization conflict.

### DIFF
--- a/serialization.h
+++ b/serialization.h
@@ -309,12 +309,14 @@ inline void serialize(Archive & ar, std::vector<T, Allocator> & t, unsigned int 
   boost::serialization::split_free(ar, t, file_version);
 }
 
+#if BOOST_VERSION < 105600
 // array
 template<class Archive, class T, size_t N>
 inline void serialize(Archive & ar, std::array<T, N> &t, unsigned int) {
   for(int i = 0; i < N; ++i)
     ar & boost::serialization::make_nvp("item", t[i]);
 }
+#endif
 
 #ifdef DEBUG_STL
 // stl debug dummies

--- a/stdafx.h
+++ b/stdafx.h
@@ -54,6 +54,7 @@
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/variant.hpp>
 #include <boost/variant.hpp>
+#include <boost/version.hpp>
 #include <boost/any.hpp>
 
 #ifdef DEBUG_STL


### PR DESCRIPTION
Should take care of miki151/keeperrl#460.
