### PR TITLE
Leave obj directory creation to git instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,7 @@ DEPS = $(addprefix $(OBJDIR)/,$(SRCS:.cpp=.d))
 ##############################################################################
 
 
-all: $(OBJDIR) $(OBJDIR)/extern $(NAME)
-
-$(OBJDIR):
-	mkdir $(OBJDIR)
-$(OBJDIR)/extern:
-	mkdir $(OBJDIR)/extern
+all: $(NAME)
 
 stdafx.h.gch: stdafx.h
 	$(CC) -x c++-header $< -MMD $(CFLAGS) -o $@

--- a/obj-opt/.gitignore
+++ b/obj-opt/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/obj-opt/extern/.gitignore
+++ b/obj-opt/extern/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/obj/.gitignore
+++ b/obj/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/obj/extern/.gitignore
+++ b/obj/extern/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This is a "do once at start and never again" action, seeing as
the make clean target doesn't remove the folders. It's easier
to just let git do this at clone time.

Fixes #484.
