### PR TITLE
Add default userPath on Linux when XDG_DATA_HOME is undefined + handle USER_DIR properly

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -63,10 +63,6 @@
 #define DATA_DIR "."
 #endif
 
-#ifndef USER_DIR
-#define USER_DIR "."
-#endif
-
 static void initializeRendererTiles(Renderer& r, const DirectoryPath& path) {
   r.loadTilesFromDir(path.subdirectory("orig16"), Vec2(16, 16));
 //  r.loadAltTilesFromDir(path + "/orig16_scaled", Vec2(24, 24));
@@ -285,12 +281,20 @@ static int keeperMain(po::parser& commandLineFlags) {
   DirectoryPath userPath([&] () -> string {
     if (commandLineFlags["user_dir"].was_set())
       return commandLineFlags["user_dir"].get().string;
+#ifdef USER_DIR
+    else if (const char* userDir = USER_DIR)
+      return userDir;
+#endif // USER_DIR
 #ifndef WINDOWS
     else if (const char* localPath = std::getenv("XDG_DATA_HOME"))
       return localPath + string("/KeeperRL");
 #endif
+#ifdef __linux__ // Some environments don't define XDG_DATA_HOME
+    else if (const char* homePath = std::getenv("HOME"))
+      return homePath + string("/.local/share/KeeperRL");
+#endif // __linux__
     else
-      return USER_DIR;
+      return ".";
   }());
   INFO << "Data path: " << dataPath;
   INFO << "User path: " << userPath;


### PR DESCRIPTION
The lookup order for the userPath is now:
1. --user-dir command-line switch
2. USER_DIR compilation macro if defined, since if it was defined it is meant to have a high priority
3. XDG_DATA_HOME/KeeperRL is XDG_DATA_HOME is defined in the environment
4. On Linux, HOME/.local/share/KeeperRL (i.e. default path if XDG_DATA_HOME were defined)
5. Current dir
