### PR TITLE
Ghosts are not always visible.

### DIFF
--- a/creature_factory.cpp
+++ b/creature_factory.cpp
@@ -1096,6 +1096,7 @@ CreatureAttributes CreatureFactory::getAttributesFromId(CreatureId id) {
           c.attr = LIST(25_def, 5_spell_dam, 120_spd );
           c.courage = 10;
           c.spawnType = SpawnType::DEMON;
+    	  c.spells->add(SpellId::INVISIBILITY);
           c.barehandedAttack = AttackType::POSSESS;
           c.body = Body::nonHumanoidSpirit(Body::Size::LARGE);
           c.permanentEffects[LastingEffect::FLYING] = 1;

--- a/creature_factory.cpp
+++ b/creature_factory.cpp
@@ -1096,7 +1096,7 @@ CreatureAttributes CreatureFactory::getAttributesFromId(CreatureId id) {
           c.attr = LIST(25_def, 5_spell_dam, 120_spd );
           c.courage = 10;
           c.spawnType = SpawnType::DEMON;
-    	  c.spells->add(SpellId::INVISIBILITY);
+          c.spells->add(SpellId::INVISIBILITY);
           c.barehandedAttack = AttackType::POSSESS;
           c.body = Body::nonHumanoidSpirit(Body::Size::LARGE);
           c.permanentEffects[LastingEffect::FLYING] = 1;

--- a/creature_factory.cpp
+++ b/creature_factory.cpp
@@ -1210,7 +1210,7 @@ CreatureAttributes CreatureFactory::getAttributesFromId(CreatureId id) {
           c.name->setFirst(NameGenerator::get(NameGeneratorId::DRAGON)->getNext());
           c.spells->add(SpellId::HEAL_SELF);
           c.spells->add(SpellId::CURE_POISON);
-          c.spells->add(SpellId::DECEPTION);
+          //c.spells->add(SpellId::DECEPTION);  Dragon hostile to its own illusions
           c.spells->add(SpellId::SPEED_SELF);
           c.name->setStack("dragon");
           );
@@ -1226,7 +1226,7 @@ CreatureAttributes CreatureFactory::getAttributesFromId(CreatureId id) {
           c.permanentEffects[LastingEffect::RANGED_VULNERABILITY] = 1;
           c.spells->add(SpellId::HEAL_SELF);
           c.spells->add(SpellId::CURE_POISON);
-          c.spells->add(SpellId::DECEPTION);
+          //c.spells->add(SpellId::DECEPTION);  Dragon hostile to its own illusions
           c.spells->add(SpellId::SPEED_SELF);
           c.name->setStack("dragon");
           );


### PR DESCRIPTION
It feels right for ghosts.

The invisibility spell would let ghosts be invisible for 14 turns. The cool-down on the spell is 300 turns and ghosts can't sneak attack while invisible (I tested it). So a small impact on gameplay.