### PR TITLE
Fix weird retired dungeons reported on Steam.

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -664,10 +664,20 @@ void Game::handleMessageBoard(Position pos, WCreature c) {
 }
 
 bool Game::gameWon() const {
+  if (campaign->getType() == CampaignType::ENDLESS)
+  {
+      //There are no main villains in endless mode.
+      return getGlobalTime().getVisibleInt() > 20000;
+  }
+  int mainVillainsDefeated = 0;
   for (WCollective col : getCollectives())
-    if (!col->isConquered() && col->getVillainType() == VillainType::MAIN)
-      return false;
-  return true;
+    if (col->getVillainType() == VillainType::MAIN)
+    {
+      if (!col->isConquered()) return false;
+      mainVillainsDefeated++;
+    }
+  //Conquered them all, but how many actually were there?
+  return mainVillainsDefeated > 0;
 }
 
 void Game::addEvent(const GameEvent& event) {


### PR DESCRIPTION
Reported by Zonobilbo on Steam:

http://steamcommunity.com/app/329970/discussions/0/3377008022036673351/

Change retirement conditions for free play and endless mode.

Because free play can have no main villains and endless mode never has main villains. Killing zero main villains out of zero is not victory.

