### PR TITLE
Fix stone farming of boulder traps.

### DIFF
--- a/collective_config.cpp
+++ b/collective_config.cpp
@@ -526,7 +526,7 @@ unique_ptr<Workshops> CollectiveConfig::getWorkshops() const {
           Workshops::Item::fromType(ItemType::WoodenStaff{}, 13, {CollectiveResourceId::WOOD, 20})
                   .setTechId(TechId::MAGICAL_WEAPONS),
           Workshops::Item::fromType(ItemType::Torch{}, 2, {CollectiveResourceId::WOOD, 4}),
-          Workshops::Item::fromType(ItemType::TrapItem{TrapType::BOULDER}, 20, {CollectiveResourceId::STONE, 50})
+          Workshops::Item::fromType(ItemType::TrapItem{TrapType::BOULDER}, 20, {CollectiveResourceId::STONE, 120})
                   .setTechId(TechId::TRAPS),
           Workshops::Item::fromType(ItemType::TrapItem{TrapType::POISON_GAS}, 10, {CollectiveResourceId::WOOD, 20})
                   .setTechId(TechId::TRAPS),


### PR DESCRIPTION
numCorpseItems in body.cpp is 80 to 120 at Body::Size::HUGE. So the huge boulder must be made of at least 120 stone, meaning that it must cost 120 stone or more. Otherwise, when the boulder crashes, it goes back to more stone that you put in to start with!

http://steamcommunity.com/app/329970/discussions/0/3377008022037580856/