### PR TITLE
Stub extern/iomanip.h on all libc++ systems

### DIFF
--- a/extern/iomanip.h
+++ b/extern/iomanip.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#ifdef OSX
+#include <cstddef>
+
+#ifdef _LIBCPP_VERSION
 #include <iomanip>
 #else
 


### PR DESCRIPTION
FreeBSD and OpenBSD also use libc++ by default which leads to

```c++
In file included from test.cpp:34:
In file included from ./text_serialization.h:3:
./extern/iomanip.h:160:1: error: unknown type name '_GLIBCXX_END_NAMESPACE_VERSION'
_GLIBCXX_END_NAMESPACE_VERSION
^
./extern/iomanip.h:161:1: error: expected unqualified-id
} // namespace __detail
^
```
and after llvm-mirror/libcxx@a0866c5fb502 one more
```c++
In file included from test.cpp:34:
./text_serialization.h:42:12: error: call to 'quoted' is ambiguous
  ar.os << std::quoted(t) << " ";
           ^~~~~~~~~~~
/usr/include/c++/v1/iomanip:645:1: note: candidate function [with _CharT = char, _Traits =
      std::__1::char_traits<char>, _Allocator = std::__1::allocator<char>]
quoted ( const basic_string <_CharT, _Traits, _Allocator> &__s, _CharT __delim = _CharT('"'), _CharT __esc...
^
./extern/iomanip.h:174:3: note: candidate function [with _CharT = char, _Traits = std::__1::char_traits<char>,
      _Alloc = std::__1::allocator<char>]
  quoted(const basic_string<_CharT, _Traits, _Alloc>& __string,
  ^
```