### PR TITLE
Fx rendering order

### DIFF
--- a/fx_draw_buffers.cpp
+++ b/fx_draw_buffers.cpp
@@ -5,12 +5,14 @@
 
 namespace fx {
 
-void DrawBuffers::fill(const vector<DrawParticle>& particles) {
+void DrawBuffers::clear() {
   positions.clear();
   texCoords.clear();
   colors.clear();
   elements.clear();
+}
 
+void DrawBuffers::add(const vector<DrawParticle>& particles) {
   if (particles.empty())
     return;
 

--- a/fx_draw_buffers.h
+++ b/fx_draw_buffers.h
@@ -11,7 +11,8 @@ struct DrawBuffers {
     TextureName texName;
   };
 
-  void fill(const vector<DrawParticle>&);
+  void clear();
+  void add(const vector<DrawParticle>&);
   bool empty() const {
     return elements.empty();
   }
@@ -19,6 +20,8 @@ struct DrawBuffers {
   vector<FVec2> positions;
   vector<FVec2> texCoords;
   vector<unsigned int> colors;
+
+  // TODO: group elements by TextureName
   vector<Element> elements;
 };
 }

--- a/fx_interface.cpp
+++ b/fx_interface.cpp
@@ -7,15 +7,24 @@
 namespace fx {
 
 FXId spawnEffect(FXName name, float x, float y) {
-  return spawnEffect(name, x, y, Vec2(0, 0));
+  if (auto* inst = FXManager::getInstance()) {
+    auto fpos = (FVec2(x, y) + FVec2(0.5f)) * Renderer::nominalSize;
+    InitConfig conf{fpos};
+    //conf.orderedDraw = true; // TODO: enable
+    auto instId = inst->addSystem(name, conf);
+    INFO << "FX spawn: " << ENUM_STRING(name) << " at:" << x << ", " << y;
+    return {instId.getIndex(), instId.getSpawnTime()};
+  }
+
+  return {-1, -1};
 }
 
-FXId spawnEffect(FXName name, float x, float y, Vec2 dir) {
+FXId spawnUnorderedEffect(FXName name, float x, float y, Vec2 dir) {
   if(auto *inst = FXManager::getInstance()) {
     auto fpos = (FVec2(x, y) + FVec2(0.5f)) * Renderer::nominalSize;
     auto ftargetOff = FVec2(dir.x, dir.y) * Renderer::nominalSize;
     auto instId = inst->addSystem(name, {fpos, ftargetOff});
-    INFO << "FX spawn: " << ENUM_STRING(name) << " at:" << x << ", " << y << " dir:" << dir;
+    INFO << "FX spawn unordered: " << ENUM_STRING(name) << " at:" << x << ", " << y << " dir:" << dir;
     return {instId.getIndex(), instId.getSpawnTime()};
   }
 
@@ -25,7 +34,9 @@ FXId spawnEffect(FXName name, float x, float y, Vec2 dir) {
 FXId spawnSnapshotEffect(FXName name, float x, float y, float scalar0, float scalar1) {
   if (auto* inst = FXManager::getInstance()) {
     auto fpos = (FVec2(x, y) + FVec2(0.5f)) * Renderer::nominalSize;
-    auto instId = inst->addSystem(name, {fpos, SnapshotKey{scalar0, scalar1}});
+    InitConfig config{fpos, SnapshotKey{scalar0, scalar1}};
+    //config.orderedDraw = true; // TODO: enable
+    auto instId = inst->addSystem(name, config);
     INFO << "FX spawn: " << ENUM_STRING(name) << " at:" << x << ", " << y;
     return {instId.getIndex(), instId.getSpawnTime()};
   }

--- a/fx_interface.cpp
+++ b/fx_interface.cpp
@@ -10,7 +10,7 @@ FXId spawnEffect(FXName name, float x, float y) {
   if (auto* inst = FXManager::getInstance()) {
     auto fpos = (FVec2(x, y) + FVec2(0.5f)) * Renderer::nominalSize;
     InitConfig conf{fpos};
-    //conf.orderedDraw = true; // TODO: enable
+    conf.orderedDraw = true;
     auto instId = inst->addSystem(name, conf);
     INFO << "FX spawn: " << ENUM_STRING(name) << " at:" << x << ", " << y;
     return {instId.getIndex(), instId.getSpawnTime()};
@@ -35,7 +35,7 @@ FXId spawnSnapshotEffect(FXName name, float x, float y, float scalar0, float sca
   if (auto* inst = FXManager::getInstance()) {
     auto fpos = (FVec2(x, y) + FVec2(0.5f)) * Renderer::nominalSize;
     InitConfig config{fpos, SnapshotKey{scalar0, scalar1}};
-    //config.orderedDraw = true; // TODO: enable
+    config.orderedDraw = true;
     auto instId = inst->addSystem(name, config);
     INFO << "FX spawn: " << ENUM_STRING(name) << " at:" << x << ", " << y;
     return {instId.getIndex(), instId.getSpawnTime()};

--- a/fx_interface.h
+++ b/fx_interface.h
@@ -15,8 +15,9 @@ inline bool valid(FXId id) {
 }
 
 FXId spawnEffect(FXName, float x, float y);
-FXId spawnEffect(FXName, float x, float y, Vec2 dir);
 FXId spawnSnapshotEffect(FXName, float x, float y, float scalar0 = 0.0f, float scalar1 = 0.0f);
+
+FXId spawnUnorderedEffect(FXName, float x, float y, Vec2 dir);
 
 bool isAlive(FXId);
 void kill(FXId, bool immediate = true);

--- a/fx_manager.cpp
+++ b/fx_manager.cpp
@@ -267,13 +267,15 @@ void FXManager::genQuads(vector<DrawParticle>& out, int systemIdx, Layer layer) 
   }
 }
 
-vector<DrawParticle> FXManager::genQuads(optional<Layer> layer) {
-  vector<DrawParticle> out;
+void FXManager::genQuadsUnordered(vector<DrawParticle>& out, optional<Layer> layer) {
   for (int n = 0; n < systems.size(); n++) {
-    genQuads(out, n, Layer::back);
-    genQuads(out, n, Layer::front);
+    if (systems[n].orderedDraw)
+      continue;
+    if (!layer || layer == Layer::back)
+      genQuads(out, n, Layer::back);
+    if (!layer || layer == Layer::front)
+      genQuads(out, n, Layer::front);
   }
-  return out;
 }
 
 bool FXManager::valid(ParticleSystemId id) const {

--- a/fx_manager.h
+++ b/fx_manager.h
@@ -50,7 +50,7 @@ public:
   auto& getSystems() { return systems; }
 
   void genQuads(vector<DrawParticle>&, int systemIdx, Layer);
-  vector<DrawParticle> genQuads(optional<Layer> = none);
+  void genQuadsUnordered(vector<DrawParticle>&, optional<Layer> = none);
 
   using Snapshot = vector<ParticleSystem::SubSystem>;
   struct SnapshotGroup {

--- a/fx_manager.h
+++ b/fx_manager.h
@@ -49,6 +49,7 @@ public:
   const auto& getSystems() const { return systems; }
   auto& getSystems() { return systems; }
 
+  void genQuads(vector<DrawParticle>&, int systemIdx, Layer);
   vector<DrawParticle> genQuads(optional<Layer> = none);
 
   using Snapshot = vector<ParticleSystem::SubSystem>;

--- a/fx_manager.h
+++ b/fx_manager.h
@@ -39,18 +39,16 @@ public:
   bool dead(ParticleSystemId) const; // invalid ids will be dead
   void kill(ParticleSystemId, bool immediate);
 
+  // TODO: this interface may be too fancy...
   // id cannot be invalid
   ParticleSystem &get(ParticleSystemId);
   const ParticleSystem &get(ParticleSystemId) const;
 
   ParticleSystemId addSystem(FXName, InitConfig);
 
-  vector<ParticleSystemId> aliveSystems() const;
   const auto& getSystems() const { return systems; }
   auto& getSystems() { return systems; }
-
-  void genQuads(vector<DrawParticle>&, int systemIdx, Layer);
-  void genQuadsUnordered(vector<DrawParticle>&, optional<Layer> = none);
+  void genQuads(vector<DrawParticle>&, int id, int ssid);
 
   using Snapshot = vector<ParticleSystem::SubSystem>;
   struct SnapshotGroup {

--- a/fx_particle_system.cpp
+++ b/fx_particle_system.cpp
@@ -30,6 +30,14 @@ bool SnapshotKey::operator==(const SnapshotKey& rhs) const {
   return true;
 }
 
+bool DrawParticle::isReasonable() const {
+  FRect borders(-10000.0f, -10000.0f, 10000.0f, 10000.0f);
+  for (auto& pos : positions)
+    if (!borders.contains(pos))
+      return false;
+  return true;
+}
+
 ParticleSystem::SubSystem::SubSystem() {
   for (auto& animVar : animationVars)
     animVar = 0.0f;
@@ -37,7 +45,7 @@ ParticleSystem::SubSystem::SubSystem() {
 
 ParticleSystem::ParticleSystem(FXName defId, const InitConfig& config, uint spawnTime, vector<SubSystem> snapshot)
     : subSystems(std::move(snapshot)), pos(config.pos), targetOffset(config.targetOffset), defId(defId),
-      spawnTime(spawnTime) {
+      spawnTime(spawnTime), orderedDraw(config.orderedDraw) {
   float dist = length(targetOffset);
   targetDir = dist < 0.00001f ? FVec2(1, 0) : targetOffset / dist;
   targetTileDist = dist / float(Renderer::nominalSize);

--- a/fx_particle_system.h
+++ b/fx_particle_system.h
@@ -43,6 +43,7 @@ struct InitConfig {
 
   FVec2 pos, targetOffset;
   optional<SnapshotKey> snapshotKey;
+  bool orderedDraw = false;
 };
 
 // Identifies a particluar particle system instance
@@ -75,6 +76,8 @@ struct Particle {
 };
 
 struct DrawParticle {
+  bool isReasonable() const;
+
   // TODO: compress it somehow?
   std::array<FVec2, 4> positions;
   std::array<FVec2, 4> texCoords;
@@ -117,6 +120,7 @@ struct ParticleSystem {
   float animTime = 0.0f;
   bool isDead = false;
   bool isDying = false;
+  bool orderedDraw = false;
 };
 
 struct SubSystemContext {

--- a/fx_renderer.cpp
+++ b/fx_renderer.cpp
@@ -4,7 +4,6 @@
 #include "fx_defs.h"
 #include "fx_particle_system.h"
 #include "fx_draw_buffers.h"
-#include "fx_rect.h"
 
 #include "opengl.h"
 #include "framebuffer.h"
@@ -14,10 +13,14 @@ namespace fx {
 
 static constexpr int nominalSize = Renderer::nominalSize;
 
-struct FXRenderer::View {
-  float zoom;
-  FVec2 offset;
-  IVec2 size;
+struct FXRenderer::SystemDrawInfo {
+  bool empty() const {
+    return numParticles == 0;
+  }
+
+  IRect worldRect; // in pixels
+  IVec2 fboPos;
+  int firstParticle = 0, numParticles = 0;
 };
 
 static FXRenderer *s_instance = nullptr;
@@ -55,16 +58,6 @@ FXRenderer::FXRenderer(DirectoryPath dataPath, FXManager& mgr) : mgr(mgr) {
 
 FXRenderer::~FXRenderer() { s_instance = nullptr; }
 
-void FXRenderer::initFramebuffer(IVec2 size) {
-  if (!Framebuffer::isExtensionAvailable())
-    return;
-  if (!blendFBO || blendFBO->width != size.x || blendFBO->height != size.y) {
-    INFO << "FX: creating FBO (" << size.x << ", " << size.y << ")";
-    blendFBO = std::make_unique<Framebuffer>(size.x, size.y);
-    addFBO = std::make_unique<Framebuffer>(size.x, size.y);
-  }
-}
-
 void FXRenderer::applyTexScale() {
   auto& elements = drawBuffers->elements;
   auto& texCoords = drawBuffers->texCoords;
@@ -92,44 +85,94 @@ IRect FXRenderer::visibleTiles(const View& view) {
   return IRect(iTopLeft - IVec2(1, 1), iTopLeft + iSize + IVec2(1, 1));
 }
 
-struct FXRenderer::SystemInfo {
-  bool empty() const {
-    return numParticles == 0;
-  }
-
-  FRect worldRect;
-  FVec2 fboOffset;
-  int firstParticle = 0, numParticles = 0;
-};
-
-FRect FXRenderer::boundingBox(const DrawParticle* particles, int count) {
+IRect FXRenderer::boundingBox(const DrawParticle* particles, int count) {
   if (count == 0)
-    return FRect();
+    return IRect();
 
   FVec2 min = particles[0].positions[0];
   FVec2 max = min;
 
+  // TODO: what to do with invalid data ?
   for (int n = 0; n < count; n++) {
-    auto& particle = particles[count];
+    auto& particle = particles[n];
     for (auto& pt : particle.positions) {
       min = vmin(min, pt);
       max = vmax(max, pt);
     }
   }
 
-  return FRect(min, max);
+  return {IVec2(min) - IVec2(1), IVec2(max) + IVec2(2)};
 }
 
-void FXRenderer::prepareRendering(optional<Layer> layer) {
-  auto ids = mgr.aliveSystems();
+IVec2 FXRenderer::allocateFboSpace() {
+  IVec2 size = blendFBO ? IVec2(orderedBlendFBO->width, orderedBlendFBO->height) : IVec2(256, 256);
+
+  // TODO: BIG PROBLEM: what about effects which are diagonal? They will take a lot more
+  // space than necessary; Maybe these effects should be drawn just like before
+  vector<pair<int, int>> ids;
+  ids.reserve(systemDraws.size());
+
+  int totalPixels = 0;
+
+  bool orderByHeight = false;
+  for (int n = 0; n < systemDraws.size(); n++) {
+    auto& draw = systemDraws[n];
+    if (!draw.empty()) {
+      int w = draw.worldRect.width(), h = draw.worldRect.height();
+      while (size.x < w)
+        size.x *= 2;
+      while (size.y < h)
+        size.y *= 2;
+      ids.emplace_back(orderByHeight ? -h : 0, n);
+      totalPixels += w * h;
+    }
+  }
+
+  std::sort(begin(ids), end(ids));
+
+  bool doesntFit = true;
+  while (doesntFit) {
+    IVec2 pos;
+    int maxHeight = 0;
+
+    doesntFit = false;
+    for (auto idPair : ids) {
+      int id = idPair.second;
+      auto& draw = systemDraws[id];
+      int w = draw.worldRect.width(), h = draw.worldRect.height();
+
+      if (pos.x + w > size.x)
+        pos = {0, pos.y + maxHeight};
+      if (pos.y + h > size.y) {
+        size.y *= 2;
+        doesntFit = true;
+        break;
+      }
+      draw.fboPos = pos;
+      pos.x += w;
+      maxHeight = max(maxHeight, h);
+    }
+  }
+
+  // TODO: properly handle such situation
+  DASSERT(size.x <= 2048 && size.y <= 2048);
+
+  return size;
+}
+
+void FXRenderer::prepareOrdered(optional<Layer> layer) {
+  auto ids = mgr.aliveSystems(); // TODO: alive ordered systems
   int maxId = 0;
   for (auto id : ids)
     maxId = max(maxId, (int)id);
-  systems.clear();
-  systems.resize(maxId + 1);
+  systemDraws.clear();
+  systemDraws.resize(maxId + 1);
   tempParticles.clear();
 
   for (auto id : ids) {
+    if (!mgr.get(id).orderedDraw)
+      continue;
+
     // TODO: properly handle layers
     int first = (int)tempParticles.size();
     if (!layer || layer == Layer::back)
@@ -138,17 +181,43 @@ void FXRenderer::prepareRendering(optional<Layer> layer) {
       mgr.genQuads(tempParticles, id, Layer::front);
     int count = (int)tempParticles.size() - first;
 
-    auto rect = boundingBox(&tempParticles[first], count);
-    systems[id] = {rect, FVec2(), first, count};
+    if (count > 0) {
+      auto rect = boundingBox(&tempParticles[first], count);
+      systemDraws[id] = {rect, IVec2(), first, count};
+    }
+  }
+
+  // TODO: obsługiwanie sytuacji bez FBOsów ?
+  //if (!Framebuffer::isExtensionAvailable())
+  auto fboSize = allocateFboSpace();
+  if (!orderedBlendFBO || orderedBlendFBO->width != fboSize.x || orderedBlendFBO->height != fboSize.y) {
+    INFO << "FX: creating FBO for ordered rendering (" << fboSize.x << ", " << fboSize.y << ")";
+    orderedBlendFBO = std::make_unique<Framebuffer>(fboSize.x, fboSize.y);
+    orderedAddFBO = std::make_unique<Framebuffer>(fboSize.x, fboSize.y);
+  }
+
+  // Positioning particles for FBO
+  for (int n = 0; n < (int)systemDraws.size(); n++) {
+    auto& draw = systemDraws[n];
+    if (draw.empty())
+      continue;
+    FVec2 offset(draw.fboPos - draw.worldRect.min());
+
+    for (int p = 0; p < draw.numParticles; p++) {
+      auto& particle = tempParticles[draw.firstParticle + p];
+      for (auto& pos : particle.positions)
+        pos += offset;
+    }
   }
 
   drawBuffers->clear();
   drawBuffers->add(tempParticles);
+  drawParticles(FVec2(), *orderedBlendFBO, *orderedAddFBO);
 }
 
-void FXRenderer::printSystemsInfo() {
-  for (int n = 0; n < (int)systems.size(); n++) {
-    auto& sys = systems[n];
+void FXRenderer::printSystemDrawsInfo() const {
+  for (int n = 0; n < (int)systemDraws.size(); n++) {
+    auto& sys = systemDraws[n];
     if (sys.empty())
       continue;
 
@@ -158,23 +227,120 @@ void FXRenderer::printSystemsInfo() {
   }
 }
 
-void FXRenderer::draw(float zoom, float offsetX, float offsetY, int w, int h, optional<Layer> layer) {
-  CHECK_OPENGL_ERROR();
-  View view{zoom, {offsetX, offsetY}, {w, h}};
+void FXRenderer::setView(float zoom, float offsetX, float offsetY, int w, int h) {
+  worldView = View{zoom, {offsetX, offsetY}, {w, h}};
+  fboView = visibleTiles(worldView);
+  auto size = fboView.size() * nominalSize;
 
-  auto fboView = visibleTiles(view);
-  auto fboScreenSize = fboView.size() * nominalSize;
+  if (useFramebuffer) {
+    DASSERT(Framebuffer::isExtensionAvailable());
+    if (!blendFBO || blendFBO->width != size.x || blendFBO->height != size.y) {
+      INFO << "FX: creating FBO (" << size.x << ", " << size.y << ")";
+      blendFBO = std::make_unique<Framebuffer>(size.x, size.y);
+      addFBO = std::make_unique<Framebuffer>(size.x, size.y);
+    }
+  }
+}
 
-  prepareRendering(layer);
-  //printSystemsInfo();
+void FXRenderer::drawParticles(FVec2 viewOffset, Framebuffer& blendFBO, Framebuffer& addFBO) {
+  IVec2 viewSize(blendFBO.width, blendFBO.height);
+  pushOpenglView();
 
+  blendFBO.bind();
+  SDL::glPushAttrib(GL_ENABLE_BIT);
+  SDL::glDisable(GL_SCISSOR_TEST);
+  setupOpenglView(blendFBO.width, blendFBO.height, 1.0f);
+
+  SDL::glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+  SDL::glClear(GL_COLOR_BUFFER_BIT);
+  SDL::glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
+
+  drawParticles({1.0f, viewOffset, viewSize}, BlendMode::normal);
+
+  addFBO.bind();
+  SDL::glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  SDL::glClear(GL_COLOR_BUFFER_BIT);
+
+  // TODO: Each effect could control how alpha builds up
+  SDL::glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+  drawParticles({1.0f, viewOffset, viewSize}, BlendMode::additive);
+
+  Framebuffer::unbind();
+  SDL::glPopAttrib();
+  popOpenglView();
+}
+
+void FXRenderer::drawOrdered(int systemIdx) {
+  auto& draw = systemDraws[systemIdx];
+  if (draw.empty())
+    return;
+
+  FRect rect(draw.worldRect);
+  rect = rect * worldView.zoom + worldView.offset;
+  FVec2 fboSize(orderedBlendFBO->width, orderedBlendFBO->height);
+  auto invSize = vinv(fboSize);
+  auto trect = FRect(IRect(draw.fboPos, draw.fboPos + draw.worldRect.size())) * invSize;
+
+  // TODO: rendering performance
+  auto drawQuad = [&]() {
+    SDL::glBegin(GL_QUADS);
+    SDL::glTexCoord2f(trect.x(), 1.0f - trect.ey()), SDL::glVertex2f(rect.x(), rect.ey());
+    SDL::glTexCoord2f(trect.ex(), 1.0f - trect.ey()), SDL::glVertex2f(rect.ex(), rect.ey());
+    SDL::glTexCoord2f(trect.ex(), 1.0f - trect.y()), SDL::glVertex2f(rect.ex(), rect.y());
+    SDL::glTexCoord2f(trect.x(), 1.0f - trect.y()), SDL::glVertex2f(rect.x(), rect.y());
+    SDL::glEnd();
+  };
+
+  int defaultMode = 0, defaultCombine = 0;
+  SDL::glGetTexEnviv(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, &defaultMode);
+  SDL::glGetTexEnviv(GL_TEXTURE_ENV, GL_COMBINE_RGB, &defaultCombine);
+  SDL::glEnable(GL_TEXTURE_2D);
+
+  SDL::glBlendFunc(GL_ONE, GL_SRC_ALPHA);
+  SDL::glBindTexture(GL_TEXTURE_2D, orderedBlendFBO->texId);
+  drawQuad();
+
+  // Here we're performing blend-add:
+  // - for high alpha values we're blending
+  // - for low alpha values we're adding
+  // For this to work nicely, additive textures need properly prepared alpha channel
+  SDL::glBindTexture(GL_TEXTURE_2D, orderedAddFBO->texId);
+  SDL::glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+  // These states multiply alpha by itself
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_ALPHA, GL_MODULATE);
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_SRC0_ALPHA, GL_TEXTURE);
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_SRC1_ALPHA, GL_TEXTURE);
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND0_ALPHA, GL_SRC_ALPHA);
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_ALPHA, GL_SRC_ALPHA);
+  drawQuad();
+
+  // Here we should really multiply by (1 - a), not (1 - a^2), but it looks better
+  SDL::glBlendFunc(GL_ONE_MINUS_SRC_ALPHA, GL_ONE);
+  drawQuad();
+
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, defaultMode);
+  SDL::glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, defaultCombine);
+}
+
+void FXRenderer::drawAllOrdered() {
+  for (int n = 0; n < systemDraws.size(); n++)
+    if (!systemDraws[n].empty())
+      drawOrdered(n);
+}
+
+void FXRenderer::drawUnordered(optional<Layer> layer) {
+  tempParticles.clear();
+  drawBuffers->clear();
+  mgr.genQuadsUnordered(tempParticles, layer);
+  drawBuffers->add(tempParticles);
   if (drawBuffers->empty())
     return;
 
-  applyTexScale();
+  CHECK_OPENGL_ERROR();
 
-  if (useFramebuffer)
-    initFramebuffer(fboScreenSize);
+  applyTexScale();
 
   SDL::glPushAttrib(GL_ENABLE_BIT);
   SDL::glDisable(GL_DEPTH_TEST);
@@ -182,31 +348,7 @@ void FXRenderer::draw(float zoom, float offsetX, float offsetY, int w, int h, op
   SDL::glEnable(GL_TEXTURE_2D);
 
   if (blendFBO && addFBO && useFramebuffer) {
-    pushOpenglView();
-    FVec2 fboOffset = -FVec2(fboView.min() * nominalSize);
-
-    blendFBO->bind();
-    SDL::glPushAttrib(GL_ENABLE_BIT);
-    SDL::glDisable(GL_SCISSOR_TEST);
-    setupOpenglView(blendFBO->width, blendFBO->height, 1.0f);
-
-    SDL::glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    SDL::glClear(GL_COLOR_BUFFER_BIT);
-    SDL::glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
-    drawParticles({1.0f, fboOffset, fboScreenSize}, BlendMode::normal);
-
-    addFBO->bind();
-    SDL::glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-    SDL::glClear(GL_COLOR_BUFFER_BIT);
-
-    // TODO: Each effect could control how alpha builds up
-    SDL::glBlendFuncSeparate(GL_ONE, GL_ONE, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-    drawParticles({1.0f, fboOffset, fboScreenSize}, BlendMode::additive);
-
-    Framebuffer::unbind();
-    SDL::glPopAttrib();
-    popOpenglView();
-
+    drawParticles(-FVec2(fboView.min() * nominalSize), *blendFBO, *addFBO);
     glColor(Color::WHITE);
 
     int defaultMode = 0, defaultCombine = 0;
@@ -214,8 +356,8 @@ void FXRenderer::draw(float zoom, float offsetX, float offsetY, int w, int h, op
     SDL::glGetTexEnviv(GL_TEXTURE_ENV, GL_COMBINE_RGB, &defaultCombine);
 
     // TODO: positioning is wrong for non-integral zoom values
-    FVec2 c1 = FVec2(fboView.min() * nominalSize * zoom) + view.offset;
-    FVec2 c2 = FVec2(fboView.max() * nominalSize * zoom) + view.offset;
+    FVec2 c1 = FVec2(fboView.min() * nominalSize * worldView.zoom) + worldView.offset;
+    FVec2 c2 = FVec2(fboView.max() * nominalSize * worldView.zoom) + worldView.offset;
 
     SDL::glBlendFunc(GL_ONE, GL_SRC_ALPHA);
     SDL::glBindTexture(GL_TEXTURE_2D, blendFBO->texId);
@@ -245,9 +387,9 @@ void FXRenderer::draw(float zoom, float offsetX, float offsetY, int w, int h, op
     SDL::glTexEnvi(GL_TEXTURE_ENV, GL_COMBINE_RGB, defaultCombine);
   } else {
     SDL::glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    drawParticles(view, BlendMode::normal);
+    drawParticles(worldView, BlendMode::normal);
     SDL::glBlendFunc(GL_ONE, GL_ONE);
-    drawParticles(view, BlendMode::additive);
+    drawParticles(worldView, BlendMode::additive);
   }
 
   SDL::glPopAttrib();
@@ -255,9 +397,11 @@ void FXRenderer::draw(float zoom, float offsetX, float offsetY, int w, int h, op
   CHECK_OPENGL_ERROR();
 }
 
-pair<unsigned, unsigned> FXRenderer::fboIds() const {
-  if (blendFBO && addFBO)
+pair<unsigned, unsigned> FXRenderer::fboIds(bool ordered) const {
+  if (!ordered && blendFBO && addFBO)
     return make_pair(blendFBO->texId, addFBO->texId);
+  if (ordered && orderedBlendFBO && orderedAddFBO)
+    return make_pair(orderedBlendFBO->texId, orderedAddFBO->texId);
   return make_pair(0u, 0u);
 }
 

--- a/fx_renderer.h
+++ b/fx_renderer.h
@@ -16,6 +16,7 @@ public:
   FXRenderer(const FXRenderer &) = delete;
   void operator=(const FXRenderer &) = delete;
 
+  void prepareRendering(optional<Layer>);
   void draw(float zoom, float offsetX, float offsetY, int w, int h, optional<Layer> = none);
 
   // TODO: better way to communicate with FXRenderer ?
@@ -31,11 +32,17 @@ public:
 
   void initFramebuffer(IVec2);
   void drawParticles(const View&, BlendMode);
+  static FRect boundingBox(const DrawParticle*, int count);
+  void printSystemsInfo();
 
   FXManager& mgr;
   vector<Texture> textures;
   vector<FVec2> textureScales;
   EnumMap<TextureName, int> textureIds;
+
+  struct SystemInfo;
+  vector<SystemInfo> systems;
+  vector<DrawParticle> tempParticles;
 
   void applyTexScale();
 

--- a/fx_renderer.h
+++ b/fx_renderer.h
@@ -29,7 +29,10 @@ public:
   // TODO: back layers could always be rendered as unordered (glows)
   // they usually take more space
   void prepareOrdered(optional<Layer>);
-  void drawOrdered(int systemIdx);
+
+  // TODO: span<> would be very useful
+  // TODO: pass proper ids
+  void drawOrdered(const int* systemIds, int count);
   void drawAllOrdered();
 
   void drawUnordered(optional<Layer> = none);
@@ -63,6 +66,7 @@ public:
   struct SystemDrawInfo;
   vector<SystemDrawInfo> systemDraws;
   vector<DrawParticle> tempParticles;
+  vector<FRect> tempRects;
 
   void applyTexScale();
 

--- a/fx_renderer.h
+++ b/fx_renderer.h
@@ -26,6 +26,8 @@ public:
   void setView(float zoom, float offsetX, float offsetY, int w, int h);
 
   // TODO: proper layer support for ordered effects
+  // TODO: back layers could always be rendered as unordered (glows)
+  // they usually take more space
   void prepareOrdered(optional<Layer>);
   void drawOrdered(int systemIdx);
   void drawAllOrdered();

--- a/fx_renderer.h
+++ b/fx_renderer.h
@@ -14,7 +14,9 @@ namespace fx {
 //   composed properly with game objects;
 // - Unordered effects are drawn together into screen-sized framebuffer and are
 //   drawn to screen together
-// Effects also have layers which allow additional separation
+//
+// Effects also have layers which allow additional separation; back layer is
+// always drawn as unordered;
 class FXRenderer {
 public:
   FXRenderer(DirectoryPath, FXManager &);
@@ -24,18 +26,14 @@ public:
   void operator=(const FXRenderer &) = delete;
 
   void setView(float zoom, float offsetX, float offsetY, int w, int h);
-
-  // TODO: proper layer support for ordered effects
-  // TODO: back layers could always be rendered as unordered (glows)
-  // they usually take more space
-  void prepareOrdered(optional<Layer>);
+  void prepareOrdered();
 
   // TODO: span<> would be very useful
   // TODO: pass proper ids
   void drawOrdered(const int* systemIds, int count);
   void drawAllOrdered();
 
-  void drawUnordered(optional<Layer> = none);
+  void drawUnordered(Layer);
 
   static FXRenderer *getInstance();
 

--- a/fx_vec.h
+++ b/fx_vec.h
@@ -103,19 +103,19 @@ template <class T> vec2<T> operator*(T s, const vec2<T> &v) { return v * s; }
 template <class T> vec3<T> operator*(T s, const vec3<T> &v) { return v * s; }
 
 template <class T> vec2<T> vmin(const vec2<T> &lhs, const vec2<T> &rhs) {
-  return T(min(lhs[0], rhs[0]), min(lhs[1], rhs[1]));
+  return {min(lhs[0], rhs[0]), min(lhs[1], rhs[1])};
 }
 
 template <class T> vec3<T> vmin(const vec3<T> &lhs, const vec3<T> &rhs) {
-  return T(min(lhs[0], rhs[0]), min(lhs[1], rhs[1]), min(lhs[2], rhs[2]));
+  return {min(lhs[0], rhs[0]), min(lhs[1], rhs[1]), min(lhs[2], rhs[2])};
 }
 
 template <class T> vec2<T> vmax(const vec2<T> &lhs, const vec2<T> &rhs) {
-  return T(max(lhs[0], rhs[0]), max(lhs[1], rhs[1]));
+  return {max(lhs[0], rhs[0]), max(lhs[1], rhs[1])};
 }
 
 template <class T> vec3<T> vmax(const vec3<T> &lhs, const vec3<T> &rhs) {
-  return T(max(lhs[0], rhs[0]), max(lhs[1], rhs[1]), max(lhs[2], rhs[2]));
+  return {max(lhs[0], rhs[0]), max(lhs[1], rhs[1]), max(lhs[2], rhs[2])};
 }
 
 template <class T> auto dot(const vec2<T> &lhs, const vec2<T> &rhs) { return lhs[0] * rhs[0] + lhs[1] * rhs[1]; }

--- a/fx_view_manager.cpp
+++ b/fx_view_manager.cpp
@@ -7,6 +7,7 @@
 #include "fx_interface.h"
 #include "fx_renderer.h"
 #include "variant.h"
+#include "renderer.h"
 
 void FXViewManager::EntityInfo::clearVisibility() {
   isVisible = false;
@@ -142,15 +143,23 @@ void FXViewManager::finishFrame() {
   }
 }
 
-void FXViewManager::drawFX(GenericId id) {
+void FXViewManager::drawFX(Renderer& renderer, GenericId id) {
   auto it = entities.find(id);
   PASSERT(it != entities.end());
   auto& entity = it->second;
 
+  int ids[EntityInfo::maxEffects];
+  int num = 0;
+
   for (int n = 0; n < entity.numEffects; n++) {
     auto& effect = entity.effects[n];
     if (effect.isVisible)
-      fx::FXRenderer::getInstance()->drawOrdered(effect.id.first);
+      ids[num++] = effect.id.first;
+  }
+
+  if (num > 0) {
+    renderer.flushSprites();
+    fx::FXRenderer::getInstance()->drawOrdered(ids, num);
   }
 }
 

--- a/fx_view_manager.cpp
+++ b/fx_view_manager.cpp
@@ -154,6 +154,6 @@ void FXViewManager::addUnmanagedFX(const FXSpawnInfo& spawnInfo) {
       y = it->second.y;
     }
   }
-  auto id = fx::spawnEffect(spawnInfo.info.name, x, y, spawnInfo.targetOffset);
+  auto id = fx::spawnUnorderedEffect(spawnInfo.info.name, x, y, spawnInfo.targetOffset);
   updateParams(spawnInfo.info, id);
 }

--- a/fx_view_manager.cpp
+++ b/fx_view_manager.cpp
@@ -9,6 +9,13 @@
 #include "variant.h"
 #include "renderer.h"
 
+static fx::FXRenderer* fxRenderer = nullptr;
+
+FXViewManager::FXViewManager() {
+  fxRenderer = fx::FXRenderer::getInstance();
+}
+FXViewManager::~FXViewManager() = default;
+
 void FXViewManager::EntityInfo::clearVisibility() {
   isVisible = false;
   for (int n = 0; n < numEffects; n++)
@@ -99,9 +106,13 @@ void FXViewManager::EntityInfo::updateFX(GenericId gid) {
     }
 }
 
-void FXViewManager::beginFrame() {
+void FXViewManager::beginFrame(Renderer& renderer, float zoom, float ox, float oy) {
   for (auto& pair : entities)
     pair.second.clearVisibility();
+
+  auto size = renderer.getSize();
+  fxRenderer->setView(zoom, ox, oy, size.x, size.y);
+  fxRenderer->prepareOrdered();
 }
 
 void FXViewManager::addEntity(GenericId gid, float x, float y) {
@@ -159,8 +170,18 @@ void FXViewManager::drawFX(Renderer& renderer, GenericId id) {
 
   if (num > 0) {
     renderer.flushSprites();
-    fx::FXRenderer::getInstance()->drawOrdered(ids, num);
+    fxRenderer->drawOrdered(ids, num);
   }
+}
+
+void FXViewManager::drawUnorderedBackFX(Renderer& renderer) {
+  renderer.flushSprites();
+  fxRenderer->drawUnordered(fx::Layer::back);
+}
+
+void FXViewManager::drawUnorderedFrontFX(Renderer& renderer) {
+  renderer.flushSprites();
+  fxRenderer->drawUnordered(fx::Layer::front);
 }
 
 // TODO: unmanaged are automatically unordered; make it the same ?

--- a/fx_view_manager.cpp
+++ b/fx_view_manager.cpp
@@ -5,6 +5,7 @@
 #include "fx_variant_name.h"
 #include "fx_info.h"
 #include "fx_interface.h"
+#include "fx_renderer.h"
 #include "variant.h"
 
 void FXViewManager::EntityInfo::clearVisibility() {
@@ -135,14 +136,25 @@ void FXViewManager::finishFrame() {
 
     it->second.justShown = false;
     it->second.updateFX(it->first);
-    if (!it->second.isVisible) {
-      //INFO << "FX view: clear: " << it->first;
+    if (!it->second.isVisible)
       entities.erase(it);
-    }
     it = next;
   }
 }
 
+void FXViewManager::drawFX(GenericId id) {
+  auto it = entities.find(id);
+  PASSERT(it != entities.end());
+  auto& entity = it->second;
+
+  for (int n = 0; n < entity.numEffects; n++) {
+    auto& effect = entity.effects[n];
+    if (effect.isVisible)
+      fx::FXRenderer::getInstance()->drawOrdered(effect.id.first);
+  }
+}
+
+// TODO: unmanaged are automatically unordered; make it the same ?
 void FXViewManager::addUnmanagedFX(const FXSpawnInfo& spawnInfo) {
   auto coord = spawnInfo.position.getCoord();
   float x = coord.x, y = coord.y;

--- a/fx_view_manager.h
+++ b/fx_view_manager.h
@@ -6,6 +6,8 @@
 #include "color.h"
 #include <unordered_map>
 
+class Renderer;
+
 // TODO: fx_interface is not really needed, all fx spawning goes through FXViewManager
 class FXViewManager {
   public:
@@ -16,7 +18,7 @@ class FXViewManager {
   void addFX(GenericId, FXVariantName);
   void finishFrame();
 
-  void drawFX(GenericId);
+  void drawFX(Renderer&, GenericId);
 
   void addUnmanagedFX(const FXSpawnInfo&);
 

--- a/fx_view_manager.h
+++ b/fx_view_manager.h
@@ -16,6 +16,8 @@ class FXViewManager {
   void addFX(GenericId, FXVariantName);
   void finishFrame();
 
+  void drawFX(GenericId);
+
   void addUnmanagedFX(const FXSpawnInfo&);
 
   private:

--- a/fx_view_manager.h
+++ b/fx_view_manager.h
@@ -11,16 +11,22 @@ class Renderer;
 // TODO: fx_interface is not really needed, all fx spawning goes through FXViewManager
 class FXViewManager {
   public:
-  void beginFrame();
+  FXViewManager();
+  ~FXViewManager();
+
+  void beginFrame(Renderer&, float zoom, float ox, float oy);
+  void finishFrame();
+
   void addEntity(GenericId, float x, float y);
   // Entity identified with given id must be present!
   void addFX(GenericId, const FXInfo&);
   void addFX(GenericId, FXVariantName);
-  void finishFrame();
-
-  void drawFX(Renderer&, GenericId);
 
   void addUnmanagedFX(const FXSpawnInfo&);
+
+  void drawFX(Renderer&, GenericId);
+  void drawUnorderedBackFX(Renderer&);
+  void drawUnorderedFrontFX(Renderer&);
 
   private:
   using TypeId = variant<FXName, FXVariantName>;

--- a/map_gui.cpp
+++ b/map_gui.cpp
@@ -649,10 +649,7 @@ void MapGui::drawObjectAbs(Renderer& renderer, Vec2 pos, const ViewObject& objec
           fxViewManager->addFX(*genericId, FXInfo{FXName::FIRE, Color::WHITE, min(1.0f, burningVal * 0.05f)});
         for (auto fx : object.particleEffects)
           fxViewManager->addFX(*genericId, fx);
-
-        // TODO: optimize...
-        renderer.flushSprites();
-        fxViewManager->drawFX(*genericId);
+        fxViewManager->drawFX(renderer, *genericId);
     }
   } else {
     Vec2 tilePos = pos + movement + Vec2(size.x / 2, -3);

--- a/map_gui.cpp
+++ b/map_gui.cpp
@@ -922,6 +922,9 @@ void MapGui::renderMapObjects(Renderer& renderer, Vec2 size, milliseconds curren
   Vec2 topLeftCorner = projectOnScreen(allTiles.topLeft());
   fogOfWar.clear();
 
+  // TODO: first iterate all tiles which have to be rendered
+  // then order them properly and draw all together
+
   if (fxViewManager)
     fxViewManager->beginFrame();
   for (ViewLayer layer : layout->getLayers())
@@ -1100,7 +1103,8 @@ void MapGui::drawFX(Renderer& renderer, bool front_layer) {
   auto offset = projectOnScreen(Vec2(0, 0));
   auto size = renderer.getSize();
   auto layer = front_layer ? fx::Layer::front : fx::Layer::back;
-  fx::FXRenderer::getInstance()->draw(zoom, offset.x, offset.y, size.x, size.y, layer);
+  fx::FXRenderer::getInstance()->setView(zoom, offset.x, offset.y, size.x, size.y);
+  fx::FXRenderer::getInstance()->drawUnordered(layer);
 }
 
 void MapGui::updateFX(milliseconds currentTimeReal) {

--- a/map_gui.cpp
+++ b/map_gui.cpp
@@ -649,6 +649,10 @@ void MapGui::drawObjectAbs(Renderer& renderer, Vec2 pos, const ViewObject& objec
           fxViewManager->addFX(*genericId, FXInfo{FXName::FIRE, Color::WHITE, min(1.0f, burningVal * 0.05f)});
         for (auto fx : object.particleEffects)
           fxViewManager->addFX(*genericId, fx);
+
+        // TODO: optimize...
+        renderer.flushSprites();
+        fxViewManager->drawFX(*genericId);
     }
   } else {
     Vec2 tilePos = pos + movement + Vec2(size.x / 2, -3);
@@ -925,8 +929,10 @@ void MapGui::renderMapObjects(Renderer& renderer, Vec2 size, milliseconds curren
   // TODO: first iterate all tiles which have to be rendered
   // then order them properly and draw all together
 
-  if (fxViewManager)
+  if (fxViewManager) {
     fxViewManager->beginFrame();
+    fx::FXRenderer::getInstance()->prepareOrdered(none);
+  }
   for (ViewLayer layer : layout->getLayers())
     if ((int)layer < (int)ViewLayer::CREATURE) {
       for (Vec2 wpos : allTiles) {

--- a/map_gui.h
+++ b/map_gui.h
@@ -195,5 +195,4 @@ class MapGui : public GuiElem {
   //double lastFxTimeReal = -1.0, lastFxTimeTurn = -1.0;
   unique_ptr<FXViewManager> fxViewManager;
   void updateFX(milliseconds currentTimeReal);
-  void drawFX(Renderer&, bool front_layer);
 };


### PR DESCRIPTION
Effects spawned through FXViewManager (except unmanaged effects) are drawn properly behind creatures.