### PR TITLE
FX: framebuffers are no longer necessary for FXes to work

### DIFF
--- a/framebuffer.cpp
+++ b/framebuffer.cpp
@@ -3,8 +3,8 @@
 #include "debug.h"
 #include "opengl.h"
 
-bool Framebuffer::isExtensionAvailable() {
-  static bool isAvailable = isOpenglExtensionAvailable("GL_ARB_framebuffer_object");
+bool Framebuffer::isAvailable() {
+  static bool isAvailable = isOpenglFeatureAvailable(OpenglFeature::FRAMEBUFFER);
   return isAvailable;
 }
 

--- a/framebuffer.h
+++ b/framebuffer.h
@@ -9,7 +9,7 @@ class Framebuffer {
   void operator=(const Framebuffer&) = delete;
   Framebuffer(const Framebuffer&) = delete;
 
-  static bool isExtensionAvailable();
+  static bool isAvailable();
 
   void bind();
   static void unbind();

--- a/fx_draw_buffers.cpp
+++ b/fx_draw_buffers.cpp
@@ -12,16 +12,18 @@ void DrawBuffers::clear() {
   elements.clear();
 }
 
-void DrawBuffers::add(const vector<DrawParticle>& particles) {
-  if (particles.empty())
+void DrawBuffers::add(const DrawParticle* particles, int count) {
+  if (count == 0 || !particles)
     return;
 
   PROFILE;
-  auto& first = particles.front();
-  elements.emplace_back(Element{0, 0, first.texName});
+  auto& first = particles[0];
+  if (elements.empty())
+    elements.emplace_back(Element{0, 0, first.texName});
 
   // TODO: sort particles by texture ?
-  for (auto& quad : particles) {
+  for (int n = 0; n < count; n++) {
+    auto& quad = particles[n];
     auto* last = &elements.back();
     if (last->texName != quad.texName) {
       Element new_elem{(int)positions.size(), 0, quad.texName};

--- a/fx_draw_buffers.h
+++ b/fx_draw_buffers.h
@@ -12,7 +12,8 @@ struct DrawBuffers {
   };
 
   void clear();
-  void add(const vector<DrawParticle>&);
+  // TODO: span would be useful
+  void add(const DrawParticle*, int count);
   bool empty() const {
     return elements.empty();
   }

--- a/fx_renderer.h
+++ b/fx_renderer.h
@@ -62,7 +62,7 @@ public:
 
   struct SystemDrawInfo;
   vector<SystemDrawInfo> systemDraws;
-  vector<DrawParticle> tempParticles;
+  vector<DrawParticle> orderedParticles, tempParticles;
   vector<FRect> tempRects;
 
   void applyTexScale();

--- a/opengl.h
+++ b/opengl.h
@@ -30,6 +30,8 @@ void glColor(const Color&);
 void glQuad(float x, float y, float ex, float ey);
 void initializeGLExtensions();
 
+enum class OpenglFeature { FRAMEBUFFER, SEPARATE_BLEND_FUNC, DEBUG };
+bool isOpenglFeatureAvailable(OpenglFeature);
 
 #ifdef WINDOWS
 


### PR DESCRIPTION
I haven't tested it on windows, but it should work :)
I haven't added full blend-add support (which makes additive particles like fire look less white) but it's minor  problem IMO (because it affects small number of players and lack of pixelization is more visible anyways).