### PR TITLE
Add Cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,109 @@
+cmake_minimum_required (VERSION 2.6)
+project(keeper)
+
+# set default cxxflags
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -ftemplate-depth=512")
+# clang specific cflags
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags")
+endif()
+
+set(STDAFX_H "${CMAKE_CURRENT_SOURCE_DIR}/stdafx.h")
+set(STDAFX_H_GCH "${CMAKE_CURRENT_BINARY_DIR}/stdagx.h.gch")
+
+# set debug cxxflags
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wimplicit-fallthrough -Wno-unused-function")
+if ((${CMAKE_BUILD_TYPE} MATCHES "Debug") AND (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gdb-index")
+endif()
+
+# additional cmake modules directory
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+
+# find required libraries
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(OpenGL REQUIRED)
+find_package (Threads REQUIRED)
+find_package(CURL REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(OpenAL REQUIRED)
+find_package(Vorbis REQUIRED)
+find_package(VorbisFile REQUIRED)
+
+# generate version.h
+file(GLOB GENERATE_VERSION_SH "gen_version.sh")
+set(KEEPER_VERSION_H "${CMAKE_CURRENT_SOURCE_DIR}/version.h")
+add_custom_command(
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/
+    COMMAND ${GENERATE_VERSION_SH}
+    DEPENDS ${GENERATE_VERSION_SH}
+    OUTPUT ${KEEPER_VERSION_H}
+    COMMENT "Generating version.h"
+)
+
+
+# rules to create `keeper` binary
+file(GLOB SOURCES "*.cpp")
+add_executable(keeper ${SOURCES} ${KEEPER_VERSION_H})
+target_include_directories(keeper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(keeper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/extern)
+target_include_directories(keeper PRIVATE ${SDL2_INCLUDE_DIRS})
+target_link_libraries(keeper PRIVATE 
+    ${SDL2_LIBRARIES}
+    ${SDL2_IMAGE_LIBRARY}
+    ${OPENGL_gl_LIBRARY}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CURL_LIBRARIES}
+    ${ZLIB_LIBRARIES}
+    ${OPENAL_LIBRARY}
+    ${VORBIS_LIBRARIES}
+    ${VorbisFile_LIBRARIES}
+    )
+
+# set up definitions
+if ((${CMAKE_BUILD_TYPE} MATCHES "Release"))
+    target_compile_definitions(keeper PRIVATE RELEASE=1)
+else()
+# generate stdafx.h.gch for debug build
+# workaround to unquote the cxxflags
+set(CXX_FLAGS_LIST ${CMAKE_CXX_FLAGS})
+separate_arguments(CXX_FLAGS_LIST)
+add_custom_command(
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/
+    COMMAND ${CMAKE_CXX_COMPILER} ${CXX_FLAGS_LIST} -x c++-header ${STDAFX_H} -MMD -o ${STDAFX_H_GCH}
+    DEPENDS ${STDAFX_H}
+    OUTPUT ${STDAFX_H_GCH}
+    COMMENT "Generating ${STDAFX_H_GCH}"
+)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include-pch ${STDAFX_H_GCH}")
+endif()
+target_sources(keeper PRIVATE ${STDAFX_H_GCH})
+endif()
+
+if(DATA_DIR)
+    target_compile_definitions(keeper PRIVATE DATA_DIR=${DATA_DIR})
+endif()
+if(USER_DIR)
+    target_compile_definitions(keeper PRIVATE USER_DIR=${USER_DIR})
+endif()
+if(DEBUG_STL)
+    target_compile_definitions(keeper PRIVATE DEBUG_STL=1)
+endif()
+if(TEXT_SERIALIZATION)
+    target_compile_definitions(keeper PRIVATE TEXT_SERIALIZATION=1)
+endif()
+if(ENABLE_LOCAL_USER_DIR)
+    target_compile_definitions(keeper PRIVATE ENABLE_LOCAL_USER_DIR=1)
+endif()
+if(SANITIZE)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+endif()
+if(PROF)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
+endif()
+if(EASY_PROFILER)
+    target_compile_definitions(keeper PRIVATE EASY_PROFILER=1)
+    target_link_libraries(keeper PRIVATE libeasy_profiler)
+endif()

--- a/cmake/FindSDL2_image.cmake
+++ b/cmake/FindSDL2_image.cmake
@@ -1,0 +1,102 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindSDL2_image
+# -------------
+#
+# Locate SDL2_image library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_IMAGE_LIBRARIES, the name of the library to link against
+#   SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+#   SDL2_IMAGE_FOUND, if false, do not try to link against
+#   SDL2_IMAGE_VERSION_STRING - human-readable string containing the
+#                              version of SDL2_image
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+#   SDL2IMAGE_LIBRARY (same value as SDL2_IMAGE_LIBRARIES)
+#   SDL2IMAGE_INCLUDE_DIR (same value as SDL2_IMAGE_INCLUDE_DIRS)
+#   SDL2IMAGE_FOUND (same value as SDL2_IMAGE_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+if(NOT SDL2_IMAGE_INCLUDE_DIR AND SDL2IMAGE_INCLUDE_DIR)
+  set(SDL2_IMAGE_INCLUDE_DIR ${SDL2IMAGE_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+    ${SDL2_DIR}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2 include
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_IMAGE_LIBRARY AND SDL2IMAGE_LIBRARY)
+  set(SDL2_IMAGE_LIBRARY ${SDL2IMAGE_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
+endif()
+find_library(SDL2_IMAGE_LIBRARY
+  NAMES SDL2_image
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+    ${SDL2_DIR}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL2_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h" SDL2_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL2_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h" SDL2_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL2_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MAJOR "${SDL2_IMAGE_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MINOR "${SDL2_IMAGE_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_PATCH "${SDL2_IMAGE_VERSION_PATCH_LINE}")
+  set(SDL2_IMAGE_VERSION_STRING ${SDL2_IMAGE_VERSION_MAJOR}.${SDL2_IMAGE_VERSION_MINOR}.${SDL2_IMAGE_VERSION_PATCH})
+  unset(SDL2_IMAGE_VERSION_MAJOR_LINE)
+  unset(SDL2_IMAGE_VERSION_MINOR_LINE)
+  unset(SDL2_IMAGE_VERSION_PATCH_LINE)
+  unset(SDL2_IMAGE_VERSION_MAJOR)
+  unset(SDL2_IMAGE_VERSION_MINOR)
+  unset(SDL2_IMAGE_VERSION_PATCH)
+endif()
+
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
+                                  REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+# for backward compatibility
+set(SDL2IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARIES})
+set(SDL2IMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIRS})
+set(SDL2IMAGE_FOUND ${SDL2_IMAGE_FOUND})
+
+mark_as_advanced(SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)

--- a/cmake/FindVorbis.cmake
+++ b/cmake/FindVorbis.cmake
@@ -1,0 +1,22 @@
+# - Try to find vorbis
+# Once done this will define
+#
+# VORBIS_FOUND - system has libvorbis
+# VORBIS_INCLUDE_DIRS - the libvorbis include directory
+# VORBIS_LIBRARIES - The libvorbis libraries
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules (VORBIS vorbis)
+  list(APPEND VORBIS_INCLUDE_DIRS ${VORBIS_INCLUDEDIR})
+endif()
+
+if(NOT VORBIS_FOUND)
+  find_path(VORBIS_INCLUDE_DIRS vorbis/vorbisenc.h)
+  find_library(VORBIS_LIBRARIES vorbis)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Vorbis DEFAULT_MSG VORBIS_INCLUDE_DIRS VORBIS_LIBRARIES)
+
+mark_as_advanced(VORBIS_INCLUDE_DIRS VORBIS_LIBRARIES)

--- a/cmake/FindVorbisFile.cmake
+++ b/cmake/FindVorbisFile.cmake
@@ -1,0 +1,75 @@
+# Locate VorbisFile
+# This module defines
+# VorbisFile_LIBRARIES
+# VorbisFile_FOUND, if false, do not try to link to VorbisFile
+# VorbisFile_INCLUDE_DIRS, where to find the headers
+#
+# $VORBISDIR is an environment variable that would
+# correspond to the ./configure --prefix=$VORBISDIR
+# used in building Vorbis.
+#
+# Created by Sukender (Benoit Neil). Based on FindOpenAL.cmake module.
+# TODO Add hints for linux and Mac
+
+FIND_PATH(VorbisFile_INCLUDE_DIRS
+	vorbis/vorbisfile.h
+	HINTS
+	$ENV{VORBISDIR}
+    $ENV{CSP_DEVPACK}
+	$ENV{VORBIS_PATH}
+	PATH_SUFFIXES include
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+)
+
+FIND_LIBRARY(VorbisFile_LIBRARIES 
+	NAMES vorbisfile
+	HINTS
+	$ENV{VORBISDIR}
+	$ENV{VORBIS_PATH}
+    $ENV{CSP_DEVPACK}
+	PATH_SUFFIXES win32/VorbisFile_Dynamic_Release lib
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw
+	/opt/local
+	/opt/csw
+	/opt
+)
+
+FIND_LIBRARY(VorbisFile_LIBRARIES_DEBUG 
+	NAMES VorbisFile_d
+	HINTS
+	$ENV{VORBISDIR}
+    $ENV{CSP_DEVPACK}
+	$ENV{VORBIS_PATH}
+	PATH_SUFFIXES win32/VorbisFile_Dynamic_Debug lib
+	PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw
+	/opt/local
+	/opt/csw
+	/opt
+)
+
+SET(VorbisFile_FOUND "NO")
+IF(VorbisFile_LIBRARIES AND VorbisFile_INCLUDE_DIRS)
+	SET(VorbisFile_FOUND "YES")
+	MARK_AS_ADVANCED(VorbisFile_LIBRARIES VorbisFile_LIBRARIES_DEBUG VorbisFile_INCLUDE_DIRS)
+ELSEIF(VorbisFile_FIND_REQUIRED)
+	MESSAGE(FATAL_ERROR "Required library VorbisFile not found! Install the library (including dev packages) and try again. If the library is already installed, set the missing variables manually in cmake.")
+ENDIF()
+

--- a/fx_particle_system.cpp
+++ b/fx_particle_system.cpp
@@ -162,7 +162,7 @@ void defaultEmitParticle(AnimationContext &ctx, EmissionState &em, Particle &new
 }
 
 array<FVec2, 4> DrawContext::quadCorners(FVec2 pos, FVec2 size, float rotation) const {
-  PASSERT(size.x >= 0 && size.y >= 0) << size.x << " " << size.y;
+  PASSERT(size.x >= 0 && size.y >= 0);// << size.x << " " << size.y;
   auto corners = FRect(pos - size * 0.5f, pos + size * 0.5f).corners();
   if (rotation != 0.0f) {
     auto sc = sincos(rotation);


### PR DESCRIPTION
Adds a cmake build configuration. This makes it easier to handle dependencies and should make the build portable to other platforms.

```
mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Release
make -j8
```

or with ninja

```
mkdir build && cd build
cmake -GNinja -DCMAKE_BUILD_TYPE=Release
ninja
```

set `CXX` to your preferred compiler before building