### PR TITLE
Prefer git date and SOURCE_DATE_EPOCH

### DIFF
--- a/gen_version.sh
+++ b/gen_version.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 VERSION="`git describe --abbrev=4 --dirty --always`"
-DATE="`date +%F`"
+EPOCH=`git log --format=%ct -1`
+[ -n "$EPOCH" ] || EPOCH=$SOURCE_DATE_EPOCH
+[ -n "$EPOCH" ] || EPOCH=`date +%s`
+DATE_FMT="+%F"
+DATE=`date -u -d "@$EPOCH" $DATE_FMT 2>/dev/null || date -u -r "$EPOCH" $DATE_FMT 2>/dev/null || date -u $DATE_FMT`
 
 echo "#define BUILD_VERSION \"$VERSION\"" > version.h
 echo "#define BUILD_DATE \"$DATE\"" >> version.h


### PR DESCRIPTION
Prefer git commit date and `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call works with many versions of date.

This PR was done while working on reproducible builds for openSUSE.