### PR TITLE
IncreaseSkill and IncreaseWorkshopSkill effects

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -56,6 +56,7 @@
 #include "furniture_entry.h"
 #include "territory.h"
 #include "vision.h"
+#include "workshop_type.h"
 
 
 static void summonFX(Position pos) {
@@ -305,6 +306,48 @@ string Effects::IncreaseAttr::getDescription(const ContentFactory*) const {
 }
 
 const char* Effects::IncreaseAttr::get(const char* ifIncrease, const char* ifDecrease) const {
+  if (amount > 0)
+    return ifIncrease;
+  else
+    return ifDecrease;
+}
+
+bool Effects::IncreaseSkill::applyToCreature(Creature* c, Creature*) const {
+  c->you(MsgType::YOUR, ::getName(skillid) + get(" improves", " wanes"));
+  c->getAttributes().getSkills().increaseValue(skillid, amount);
+  return true;
+}
+
+string Effects::IncreaseSkill::getName(const ContentFactory*) const {
+  return ::getName(skillid) + get(" proficency boost", " proficency loss");
+}
+
+string Effects::IncreaseSkill::getDescription(const ContentFactory*) const {
+  return get("Increases", "Decreases") + " "_s + ::getName(skillid) + " by " + toString(abs(amount));
+}
+
+const char* Effects::IncreaseSkill::get(const char* ifIncrease, const char* ifDecrease) const {
+  if (amount > 0)
+    return ifIncrease;
+  else
+    return ifDecrease;
+}
+
+bool Effects::IncreaseWorkshopSkill::applyToCreature(Creature* c, Creature*) const {
+  c->you(MsgType::YOUR, c->getGame()->getContentFactory()->workshopInfo.at(workshoptype).name + get(" improves", " wanes"));
+  c->getAttributes().getSkills().increaseValue(workshoptype, amount);
+  return true;
+}
+
+string Effects::IncreaseWorkshopSkill::getName(const ContentFactory* content_factory) const {
+  return content_factory->workshopInfo.at(workshoptype).name + get(" proficency boost", " proficency loss");
+}
+
+string Effects::IncreaseWorkshopSkill::getDescription(const ContentFactory* content_factory) const {
+  return get("Increases", "Decreases") + " "_s + content_factory->workshopInfo.at(workshoptype).name + " by " + toString(abs(amount));
+}
+
+const char* Effects::IncreaseWorkshopSkill::get(const char* ifIncrease, const char* ifDecrease) const {
   if (amount > 0)
     return ifIncrease;
   else
@@ -1670,7 +1713,7 @@ EffectAIIntent Effect::shouldAIApply(const Creature* victim, bool isEnemy) const
   );
 }
 
-/* Unimplemented: Teleport, EnhanceArmor, EnhanceWeapon, Suicide, IncreaseAttr,
+/* Unimplemented: Teleport, EnhanceArmor, EnhanceWeapon, Suicide, IncreaseAttr, IncreaseSkill, IncreaseWorkshopSkill
       EmitPoisonGas, CircularBlast, Alarm, SilverDamage, DoubleTrouble,
       PlaceFurniture, InjureBodyPart, LooseBodyPart, RegrowBodyPart, DestroyWalls,
       ReviveCorpse, Blast, Shove, SwapPosition*/

--- a/effect_type.h
+++ b/effect_type.h
@@ -10,6 +10,7 @@
 #include "sound.h"
 #include "color.h"
 #include "fx_info.h"
+#include "workshop_type.h"
 
 RICH_ENUM(FilterType, ALLY, ENEMY, AUTOMATON);
 
@@ -134,6 +135,20 @@ struct IncreaseAttr {
   int SERIAL(amount);
   const char* get(const char* ifIncrease, const char* ifDecrease) const;
   SERIALIZE_ALL(attr, amount)
+};
+struct IncreaseSkill {
+  EFFECT_TYPE_INTERFACE;
+  SkillId SERIAL(skillid);
+  double SERIAL(amount);
+  const char* get(const char* ifIncrease, const char* ifDecrease) const;
+  SERIALIZE_ALL(skillid, amount)
+};
+struct IncreaseWorkshopSkill {
+  EFFECT_TYPE_INTERFACE;
+  WorkshopType SERIAL(workshoptype);
+  double SERIAL(amount);
+  const char* get(const char* ifIncrease, const char* ifDecrease) const;
+  SERIALIZE_ALL(workshoptype, amount)
 };
 struct InjureBodyPart {
   EFFECT_TYPE_INTERFACE;
@@ -369,7 +384,9 @@ struct AITargetEnemy {
   X(Description, 60)\
   X(Name, 61)\
   X(AIBelowHealth, 62)\
-  X(AITargetEnemy, 63)
+  X(AITargetEnemy, 63)\
+  X(IncreaseSkill, 64)\
+  X(IncreaseWorkshopSkill, 65)\
 
 #define VARIANT_TYPES_LIST EFFECT_TYPES_LIST
 #define VARIANT_NAME EffectType

--- a/skill.cpp
+++ b/skill.cpp
@@ -22,6 +22,10 @@
 #include "creature_attributes.h"
 #include "content_factory.h"
 
+string getName(SkillId skillid) {
+  return Skill::get(skillid)->getName();
+}
+
 string Skill::getName() const {
   return name;
 }
@@ -76,6 +80,10 @@ void Skillset::setValue(WorkshopType s, double v) {
 
 void Skillset::increaseValue(SkillId s, double v) {
   values[s] = max(0.0, min(1.0, values[s] + v));
+}
+
+void Skillset::increaseValue(WorkshopType type, double v) {
+  workshopValues[type] = max(0.0, min(1.0, workshopValues[type] + v));
 }
 
 SERIALIZE_DEF(Skillset, values, workshopValues)

--- a/skill.h
+++ b/skill.h
@@ -30,6 +30,8 @@ RICH_ENUM(SkillId,
 class Creature;
 class ContentFactory;
 
+extern string getName(SkillId);
+
 class Skill : public Singleton<Skill, SkillId> {
   public:
   string getName() const;
@@ -56,6 +58,7 @@ class Skillset {
   void setValue(SkillId, double);
   void setValue(WorkshopType, double);
   void increaseValue(SkillId, double);
+  void increaseValue(WorkshopType, double);
 
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);


### PR DESCRIPTION
Allows to increase creature's skills or workshop skills permanently.

IncreaseSkill DIGGING 1.0 - would make the creature a 100% proficient digger
IncreaseWorkshopSkill "WORKSHOP" 1.0 - would make the creature a 100% proficient workshopper.