### PR TITLE
FilterLasting effect

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -1239,10 +1239,7 @@ bool Effects::FilterLasting::applyToCreature(Creature* c, Creature* attacker) co
 }
 
 string Effects::FilterLasting::getName(const ContentFactory* f) const {
-  auto suffix = [&] {
-    return " (" + LastingEffects::getName(filter_effect) + " creatures only)";
-  };
-  return effect->getName(f) + suffix();
+  return effect->getName(f) + " (" + LastingEffects::getName(filter_effect) + " creatures only)";
 }
 
 string Effects::FilterLasting::getDescription(const ContentFactory* f) const {
@@ -1858,10 +1855,11 @@ optional<FXInfo> Effect::getProjectileFX() const {
       [&](const Effects::Description& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); },
       [&](const Effects::Name& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); },
       [&](const Effects::AIBelowHealth& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); },
-      [&](const Effects::AITargetEnemy& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); }
+      [&](const Effects::AITargetEnemy& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); },
+      [&](const Effects::Filter& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); },
+      [&](const Effects::FilterLasting& e) -> optional<FXInfo> { return e.effect->getProjectileFX(); }
   );
 }
-
 optional<ViewId> Effect::getProjectile() const {
   return effect->visit<optional<ViewId>>(
       [&](const auto&) -> optional<ViewId> { return none; },
@@ -1873,7 +1871,9 @@ optional<ViewId> Effect::getProjectile() const {
       [&](const Effects::Description& e) -> optional<ViewId> { return e.effect->getProjectile(); },
       [&](const Effects::Name& e) -> optional<ViewId> { return e.effect->getProjectile(); },
       [&](const Effects::AIBelowHealth& e) -> optional<ViewId> { return e.effect->getProjectile(); },
-      [&](const Effects::AITargetEnemy& e) -> optional<ViewId> { return e.effect->getProjectile(); }
+      [&](const Effects::AITargetEnemy& e) -> optional<ViewId> { return e.effect->getProjectile(); },
+      [&](const Effects::Filter& e) -> optional<ViewId> { return e.effect->getProjectile(); },
+      [&](const Effects::FilterLasting& e) -> optional<ViewId> { return e.effect->getProjectile(); }
   );
 }
 

--- a/effect.cpp
+++ b/effect.cpp
@@ -1230,6 +1230,28 @@ string Effects::Fx::getDescription(const ContentFactory*) const {
   return "Just a visual effect";
 }
 
+bool Effects::FilterLasting::applies(const Creature* c, const Creature* attacker) const {
+  return !!c && c->isAffected(filter_effect);
+}
+
+bool Effects::FilterLasting::applyToCreature(Creature* c, Creature* attacker) const {
+  return applies(c, attacker) && effect->apply(c->getPosition(), attacker);
+}
+
+string Effects::FilterLasting::getName(const ContentFactory* f) const {
+  auto suffix = [&] {
+    return " (" + LastingEffects::getName(filter_effect) + " creatures only)";
+  };
+  return effect->getName(f) + suffix();
+}
+
+string Effects::FilterLasting::getDescription(const ContentFactory* f) const {
+  auto suffix = [&] {
+    return " (applied only to creatures with " + LastingEffects::getName(filter_effect) + " effect)";
+  };
+  return effect->getDescription(f) + suffix();
+}
+
 bool Effects::Filter::applies(const Creature* c, const Creature* attacker) const {
   switch (filter) {
     case FilterType::ALLY:
@@ -1771,6 +1793,11 @@ EffectAIIntent Effect::shouldAIApply(const Creature* caster, Position pos) const
           return e.effect->shouldAIApply(caster, pos);
         return EffectAIIntent::NONE;
       },
+      [&] (const Effects::FilterLasting& e) {
+        if (victim && e.applies(victim, caster))
+          return e.effect->shouldAIApply(caster, pos);
+        return EffectAIIntent::NONE;
+      },
       [&] (const Effects::Chance& e) {
         return e.effect->shouldAIApply(caster, pos);
       },
@@ -1890,6 +1917,7 @@ optional<MinionEquipmentType> Effect::getMinionEquipmentType() const {
       [&](const Effects::AITargetEnemy& e) -> optional<MinionEquipmentType> { return e.effect->getMinionEquipmentType(); },
       [&](const Effects::Area& a) -> optional<MinionEquipmentType> { return a.effect->getMinionEquipmentType(); },
       [&](const Effects::Filter& f) -> optional<MinionEquipmentType> { return f.effect->getMinionEquipmentType(); },
+      [&](const Effects::FilterLasting& f) -> optional<MinionEquipmentType> { return f.effect->getMinionEquipmentType(); },
       [&](const Effects::Escape&) -> optional<MinionEquipmentType> { return MinionEquipmentType::COMBAT_ITEM; },
       [&](const Effects::Chain& c) -> optional<MinionEquipmentType> {
         for (auto& e : c.effects)
@@ -1920,6 +1948,7 @@ bool Effect::canAutoAssignMinionEquipment() const {
       [&](const Effects::AITargetEnemy& e) { return e.effect->canAutoAssignMinionEquipment(); },
       [&](const Effects::Area& a) { return a.effect->canAutoAssignMinionEquipment(); },
       [&](const Effects::Filter& f) { return f.effect->canAutoAssignMinionEquipment(); },
+      [&](const Effects::FilterLasting& f) { return f.effect->canAutoAssignMinionEquipment(); },
       [&](const Effects::Chain& c) {
         for (auto& e : c.effects)
           if (!e.canAutoAssignMinionEquipment())

--- a/effect_type.h
+++ b/effect_type.h
@@ -209,6 +209,13 @@ struct Filter {
   HeapAllocated<Effect> SERIAL(effect);
   SERIALIZE_ALL(filter, effect)
 };
+struct FilterLasting {
+  EFFECT_TYPE_INTERFACE;
+  bool applies(const Creature* c, const Creature* attacker) const;
+  LastingEffect SERIAL(filter_effect);
+  HeapAllocated<Effect> SERIAL(effect);
+  SERIALIZE_ALL(filter_effect, effect)
+};
 SIMPLE_EFFECT(Wish);
 struct Caster {
   EFFECT_TYPE_INTERFACE;
@@ -387,6 +394,7 @@ struct AITargetEnemy {
   X(AITargetEnemy, 63)\
   X(IncreaseSkill, 64)\
   X(IncreaseWorkshopSkill, 65)\
+  X(FilterLasting, 66)\
 
 #define VARIANT_TYPES_LIST EFFECT_TYPES_LIST
 #define VARIANT_NAME EffectType


### PR DESCRIPTION
FilterLasting only applies the effect is the creature has the required FilterEffect.

Usage: `FilterLasting [LASTING_EFFECT_NAME] [EFFECT]`

Example:
```
"rip and tear"
{
  symbol = "💣"
  effect = Area 3 Filter ENEMY Lasting BLEEDING
  cooldown = 10
  sound = SPELL_BLAST
  message = "RIP AND TEAR" "RIPS AND TEARS"
}
"rupture enemies"
{
  symbol = "👹"
  effect = Area 3 FilterLasting BLEEDING Suicide DIE
  cooldown = 1
  sound = SPELL_BLAST
  message = "rupture enemies" "ruptures enemies"
}
```

In the example above - first spell makes enemies bleed, and the second - instantly kills bleeding enemies. However second spell would work with any kind of bleed, as long as it is on the target.

Other possible usages: "cultist" class that makes creatures temporarily insane, and can only apply debuffs/buffs to those who are insane.

"hunter" that puts "marks" on his enemies, and then has some abilities to go along with it.
