### PR TITLE
[WiP] Resistances and Immunities

### DIFF
--- a/body.cpp
+++ b/body.cpp
@@ -1016,13 +1016,13 @@ bool Body::canPush(const Body& other) {
 }
 
 bool Body::canPerformRituals() const {
-  return xhumanoid && !isImmuneTo(LastingEffect::TIED_UP);
+  return xhumanoid;
 }
 
 bool Body::canBeCaptured() const {
   if (canCapture)
     return *canCapture;
-  return xhumanoid && !isImmuneTo(LastingEffect::TIED_UP);
+  return xhumanoid;
 }
 
 bool Body::isUndead() const {

--- a/creature.cpp
+++ b/creature.cpp
@@ -2359,15 +2359,15 @@ const char* getMoraleText(double morale) {
 }
 
 AdjectiveInfo Creature::resistanceInfo(string name, LastingEffect effect) const {
-  string desc = LastingEffects::getDescription(effect);
-  desc[0] = tolower(desc[0]);
+  string desc = "Resistant to " + name;
   if (!isImmuneTo(effect)) {
     name += getAttributes().getResistanceTimeString(effect, *getGlobalTime());
   }
   else {
-    name += " immunity";
+    name += " permanently";
+    desc += " permanently";
   }
-  return { name, "Immune to anything that " + desc };
+  return { name, desc };
 }
 
 vector<AdjectiveInfo> Creature::getGoodAdjectives() const {

--- a/creature.h
+++ b/creature.h
@@ -268,10 +268,20 @@ class Creature : public Renderable, public UniqueEntity<Creature>, public OwnedO
   bool isAffected(LastingEffect, optional<GlobalTime>) const;
   bool isAffected(LastingEffect, GlobalTime) const;
   bool isAffected(LastingEffect) const;
+  bool addResistanceEffect(LastingEffect, TimeInterval, bool msg = true);
+  bool addResistanceEffect(LastingEffect, TimeInterval, GlobalTime, bool msg = true);
+  bool removeResistanceEffect(LastingEffect, bool msg = true);
+  bool addImmunityEffect(LastingEffect, int count = 1, bool msg = true);
+  bool removeImmunityEffect(LastingEffect, int count = 1, bool msg = true);
+  bool isResistantTo(LastingEffect) const;
+  bool isResistantTo(LastingEffect, GlobalTime) const;
+  bool isResistantTo(LastingEffect, optional<GlobalTime>) const;
+  bool isImmuneTo(LastingEffect) const;
   optional<TimeInterval> getTimeRemaining(LastingEffect) const;
   bool hasCondition(CreatureCondition) const;
 
   bool isUnknownAttacker(const Creature*) const;
+  AdjectiveInfo resistanceInfo(string, LastingEffect) const;
   vector<AdjectiveInfo> getGoodAdjectives() const;
   vector<AdjectiveInfo> getBadAdjectives() const;
 
@@ -304,6 +314,8 @@ class Creature : public Renderable, public UniqueEntity<Creature>, public OwnedO
   bool canBeCaptured() const;
   void removePrivateEnemy(const Creature*); 
   void cheatAllSpells();
+
+  bool canPerformRituals() const;
 
   vector<AutomatonPart> SERIAL(automatonParts);
   vector<PItem> SERIAL(drops);

--- a/creature_attributes.h
+++ b/creature_attributes.h
@@ -99,12 +99,20 @@ class CreatureAttributes {
   bool isAffectedPermanently(LastingEffect) const;
   GlobalTime getTimeOut(LastingEffect) const;
   string getRemainingString(LastingEffect, GlobalTime) const;
+  string getResistanceTimeString(LastingEffect, GlobalTime) const;
   void clearLastingEffect(LastingEffect);
   void addPermanentEffect(LastingEffect, int count);
   void removePermanentEffect(LastingEffect, int count);
   bool considerTimeout(LastingEffect, GlobalTime current);
+  bool considerResistanceTimeout(LastingEffect, GlobalTime);
   void addLastingEffect(LastingEffect, GlobalTime endtime);
   optional<GlobalTime> getLastAffected(LastingEffect, GlobalTime currentGlobalTime) const;
+  void clearResistantEffect(LastingEffect);
+  void addResistantEffect(LastingEffect, GlobalTime);
+  void addImmunityEffect(LastingEffect, int);
+  void removeImmunityEffect(LastingEffect, int);
+  bool isResistant(LastingEffect, GlobalTime) const;
+  bool isImmune(LastingEffect) const;
   bool canSleep() const;
   bool isInnocent() const;
   void consume(Creature* self, CreatureAttributes& other);
@@ -126,6 +134,7 @@ class CreatureAttributes {
   vector<ItemType> SERIAL(automatonParts);
 
   private:
+  void consumeImmunities(const EnumMap<LastingEffect, int>&);
   void consumeEffects(const EnumMap<LastingEffect, int>&);
   ViewId SERIAL(viewId);
   heap_optional<ViewObject> SERIAL(illusionViewObject);
@@ -147,6 +156,8 @@ class CreatureAttributes {
   vector<SpellId> SERIAL(spells);
   EnumMap<LastingEffect, int> SERIAL(permanentEffects);
   EnumMap<LastingEffect, GlobalTime> SERIAL(lastingEffects);
+  EnumMap<LastingEffect, int> SERIAL(immunityEffects);
+  EnumMap<LastingEffect, GlobalTime> SERIAL(resistantEffects);
   MinionActivityMap SERIAL(minionActivities);
   EnumMap<ExperienceType, double> SERIAL(expLevel);
   EnumMap<ExperienceType, int> SERIAL(maxLevelIncrease);

--- a/effect.cpp
+++ b/effect.cpp
@@ -292,6 +292,54 @@ string Effects::RemoveLasting::getDescription(const ContentFactory*) const {
   return "Removes/cures from effect: " + LastingEffects::getName(lastingEffect);
 }
 
+bool Effects::Resistant::applyToCreature(Creature* c, Creature* attacker) const {
+  return c->addResistanceEffect(lastingEffect, TimeInterval(time));
+}
+
+string Effects::Resistant::getName(const ContentFactory*) const {
+  return LastingEffects::getName(lastingEffect) + " resistance";
+}
+
+string Effects::Resistant::getDescription(const ContentFactory*) const {
+  return "Makes resistant to " + LastingEffects::getName(lastingEffect) + " for some turns.";
+}
+
+bool Effects::RemoveResistant::applyToCreature(Creature* c, Creature* attacker) const {
+  return c->removeResistanceEffect(lastingEffect);
+}
+
+string Effects::RemoveResistant::getName(const ContentFactory*) const {
+  return "remove " + LastingEffects::getName(lastingEffect) + " resistance";
+}
+
+string Effects::RemoveResistant::getDescription(const ContentFactory*) const {
+  return "Removes resistance to " + LastingEffects::getName(lastingEffect);
+}
+
+bool Effects::Immunity::applyToCreature(Creature* c, Creature* attacker) const {
+  return c->addImmunityEffect(lastingEffect, count);
+}
+
+string Effects::Immunity::getName(const ContentFactory*) const {
+  return "permanent " + LastingEffects::getName(lastingEffect) + " resistance";
+}
+
+string Effects::Immunity::getDescription(const ContentFactory*) const {
+  return "Makes resistant to " + LastingEffects::getName(lastingEffect) + " permanently.";
+}
+
+bool Effects::RemoveImmunity::applyToCreature(Creature* c, Creature* attacker) const {
+  return c->removeImmunityEffect(lastingEffect, count);
+}
+
+string Effects::RemoveImmunity::getName(const ContentFactory*) const {
+  return "remove permanent " + LastingEffects::getName(lastingEffect) + " resistance";
+}
+
+string Effects::RemoveImmunity::getDescription(const ContentFactory*) const {
+  return "Removes permanent resistance to " + LastingEffects::getName(lastingEffect);
+}
+
 bool Effects::IncreaseAttr::applyToCreature(Creature* c, Creature*) const {
   c->you(MsgType::YOUR, ::getName(attr) + get(" improves", " wanes"));
   c->getAttributes().increaseBaseAttr(attr, amount);

--- a/effect_type.h
+++ b/effect_type.h
@@ -111,6 +111,29 @@ struct RemovePermanent {
   LastingEffect SERIAL(lastingEffect);
   SERIALIZE_ALL(lastingEffect)
 };
+struct Resistant {
+  EFFECT_TYPE_INTERFACE;
+  LastingEffect SERIAL(lastingEffect);
+  int SERIAL(time) = 100;
+  SERIALIZE_ALL(lastingEffect, time);
+};
+struct RemoveResistant {
+  EFFECT_TYPE_INTERFACE;
+  LastingEffect SERIAL(lastingEffect);
+  SERIALIZE_ALL(lastingEffect);
+};
+struct Immunity {
+  EFFECT_TYPE_INTERFACE;
+  LastingEffect SERIAL(lastingEffect);
+  SERIALIZE_ALL(lastingEffect);
+  int SERIAL(count) = 1;
+};
+struct RemoveImmunity {
+  EFFECT_TYPE_INTERFACE;
+  LastingEffect SERIAL(lastingEffect);
+  SERIALIZE_ALL(lastingEffect);
+  int SERIAL(count) = 1;
+};
 struct PlaceFurniture {
   EFFECT_TYPE_INTERFACE;
   FurnitureType SERIAL(furniture);

--- a/lasting_effect.cpp
+++ b/lasting_effect.cpp
@@ -332,7 +332,7 @@ void LastingEffects::onAffected(Creature* c, LastingEffect effect, bool msg) {
 }
 
 bool LastingEffects::affects(const Creature* c, LastingEffect effect) {
-  if (c->getBody().isImmuneTo(effect))
+  if (c->isImmuneTo(effect))
     return false;
   if (auto preventing = getPreventing(effect))
     if (c->isAffected(*preventing))
@@ -379,6 +379,18 @@ void LastingEffects::onRemoved(Creature* c, LastingEffect effect, bool msg) {
     default:
       onTimedOut(c, effect, msg); break;
   }
+}
+
+void LastingEffects::onResisted(Creature* c, LastingEffect effect, bool msg) {
+  onResistanceTimedOut(c, effect, msg);
+}
+
+void LastingEffects::onResistanceTimedOut(Creature* c, LastingEffect effect, bool msg) {
+  return;
+}
+
+void LastingEffects::onSusceptible(Creature* c, LastingEffect effect, bool msg) {
+  return;
 }
 
 void LastingEffects::onTimedOut(Creature* c, LastingEffect effect, bool msg) {
@@ -758,15 +770,19 @@ static Adjective getAdjective(LastingEffect effect) {
   }
 }
 
-optional<string> LastingEffects::getGoodAdjective(LastingEffect effect) {
+optional<string> LastingEffects::getGoodAdjective(LastingEffect effect, bool inv) {
   auto adjective = getAdjective(effect);
+  if (inv)
+    adjective.bad = !adjective.bad;
   if (!adjective.bad)
     return adjective.name;
   return none;
 }
 
-optional<std::string> LastingEffects::getBadAdjective(LastingEffect effect) {
+optional<std::string> LastingEffects::getBadAdjective(LastingEffect effect, bool inv) {
   auto adjective = getAdjective(effect);
+  if (inv)
+    adjective.bad = !adjective.bad;
   if (adjective.bad)
     return adjective.name;
   return none;
@@ -1326,6 +1342,10 @@ bool LastingEffects::canConsume(LastingEffect effect) {
   }
 }
 
+bool LastingEffects::canConsumeImmunity(LastingEffect effect) {
+  return true;
+}
+
 optional<FXVariantName> LastingEffects::getFX(LastingEffect effect) {
   switch (effect) {
     case LastingEffect::SLEEP:
@@ -1436,6 +1456,10 @@ optional<FXInfo> LastingEffects::getApplicationFX(LastingEffect effect) {
     default:
       return none;
   }
+}
+
+optional<FXInfo> LastingEffects::getResistantFX(LastingEffect effect) {
+  return none;
 }
 
 bool LastingEffects::canProlong(LastingEffect effect) {

--- a/lasting_effect.h
+++ b/lasting_effect.h
@@ -99,12 +99,15 @@ class LastingEffects {
   static bool affects(const Creature*, LastingEffect);
   static optional<LastingEffect> getSuppressor(LastingEffect);
   static void onRemoved(Creature*, LastingEffect, bool msg);
+  static void onResisted(Creature*, LastingEffect, bool msg);
+  static void onSusceptible(Creature*, LastingEffect, bool msg);
   static void onTimedOut(Creature*, LastingEffect, bool msg);
+  static void onResistanceTimedOut(Creature*, LastingEffect, bool msg);
   static int getAttrBonus(const Creature*, AttrType);
   static void afterCreatureDamage(Creature*, LastingEffect);
   static bool tick(Creature*, LastingEffect);
-  static optional<string> getGoodAdjective(LastingEffect);
-  static optional<string> getBadAdjective(LastingEffect);
+  static optional<string> getGoodAdjective(LastingEffect, bool inv = false);
+  static optional<string> getBadAdjective(LastingEffect, bool inv = false);
   static const vector<LastingEffect>& getCausingCondition(CreatureCondition);
   static double modifyCreatureDefense(LastingEffect, double damage, AttrType damageAttr);
   static void onAllyKilled(Creature*);
@@ -117,8 +120,10 @@ class LastingEffects {
   static double getCraftingSpeed(const Creature*);
   static double getTrainingSpeed(const Creature*);
   static bool canConsume(LastingEffect);
+  static bool canConsumeImmunity(LastingEffect);
   static optional<FXVariantName> getFX(LastingEffect);
   static optional<FXInfo> getApplicationFX(LastingEffect);
+  static optional<FXInfo> getResistantFX(LastingEffect);
   static bool canProlong(LastingEffect);
   static bool obeysFormation(const Creature*, const Creature* against);
   static EffectAIIntent shouldAIApply(const Creature* victim, LastingEffect, bool isEnemy);

--- a/minion_activity_map.cpp
+++ b/minion_activity_map.cpp
@@ -82,7 +82,7 @@ bool MinionActivityMap::isAvailable(const Collective* col, const Creature* c, Mi
     case MinionActivity::COPULATE:
       return c->isAffected(LastingEffect::COPULATION_SKILL);
     case MinionActivity::RITUAL:
-      return c->getBody().canPerformRituals() && !col->hasTrait(c, MinionTrait::WORKER);
+      return c->canPerformRituals() && !col->hasTrait(c, MinionTrait::WORKER);
     case MinionActivity::GUARDING:
       return col->hasTrait(c, MinionTrait::FIGHTER);
     case MinionActivity::CROPS:


### PR DESCRIPTION
Adds resistantEffects and immunityEffects.

First is a temporary resistance to a lasting effect. Upon getting a resistance any temporary effect of this type that is shorter in it's span than the resistance is removed(otherwise it doesn't). Resistances do not remove permanent effects, but they suppress their action.

Second is an immunity to a lasting effect. Upon getting an immunity any temporary effect is cleared, and the permanent effects gets -count-ed. If permanent effect is removed - immunity takes place. With immunity a creature can not get temporary effect, but if a permanent effect is applied the immunity gets weaker, until it dissapears.

@miki151 I want to discuss whether I did the right thing in:
1) Seperating immunityEffect into it's own list instead of making it so negative permanentEffect-s are "immunities".
2) The whole or-deal with immunity counting down permanent effects, and vice-versa.

After these two are discussed, I can go on to work more on this, in due time I will be testing.

This PR is also not complete, and requires:
- [x] Resistant and Immunity effects.
- [ ] Replacing all "-resistant" effects with Resistant *EFFECT*. (unless the effect does anything else except preventing other effect to apply):
  - [ ] Poison-resistance
  - [ ] Sleep-resistance
  - [ ] Plague-resistance

Addresses a topic brought by #1445 