### PR TITLE
Makefile: Append CFLAGS instead of overwriting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 
-CFLAGS = -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags -ftemplate-depth=512 -Wno-implicit-conversion-floating-point-to-bool -Wno-string-conversion -Wno-bool-conversion -ftemplate-backtrace-limit=0 -Wunused-function
+CFLAGS += -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags -ftemplate-depth=512 -Wno-implicit-conversion-floating-point-to-bool -Wno-string-conversion -Wno-bool-conversion -ftemplate-backtrace-limit=0 -Wunused-function
 
 # Remove if you wish to build KeeperRL without steamworks integration.
 ifndef NO_STEAMWORKS

--- a/Makefile-win
+++ b/Makefile-win
@@ -3,7 +3,7 @@ GCC = $(PREFIX)g++
 PKG_CONFIG = $(PREFIX)pkg-config
 
 LD = $(GCC)
-CFLAGS = -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-strict-aliasing -Wl,--build-id -Wl,--large-address-aware
+CFLAGS += -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-strict-aliasing -Wl,--build-id -Wl,--large-address-aware
 
 ifdef DATA_DIR
 	CFLAGS += -DDATA_DIR=\"$(DATA_DIR)\"


### PR DESCRIPTION
This allows specifying additional CFLAGS from the command line/environment,
while ensuring that the CFLAGS defined in the Makefile will take precedence.

---

I use this on a distro package of the free version to set distro-specific optimization flags:
```
$ rpm --eval %__global_cflags
-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables
```
(Some of which are eventually overridden by e.g. `OPT=1`, but it's a baseline.)