### PR TITLE
Makefile: Allow disabling Steamworks and rpath from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ endif
 CFLAGS = -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags -ftemplate-depth=512 -Wno-implicit-conversion-floating-point-to-bool -Wno-string-conversion -Wno-bool-conversion -ftemplate-backtrace-limit=0 -Wunused-function
 
 # Remove if you wish to build KeeperRL without steamworks integration.
+ifndef NO_STEAMWORKS
 STEAMWORKS = true
+endif
 
 ifndef GCC
 GCC = g++

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 
 
-ifndef RPATH
-RPATH = .
-endif
-
 CFLAGS = -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags -ftemplate-depth=512 -Wno-implicit-conversion-floating-point-to-bool -Wno-string-conversion -Wno-bool-conversion -ftemplate-backtrace-limit=0 -Wunused-function
 
 # Remove if you wish to build KeeperRL without steamworks integration.
@@ -28,7 +24,9 @@ LDFLAGS += -Wl -L/usr/local/opt/openal-soft/lib
 CFLAGS += -stdlib=libc++ -DOSX -mmacosx-version-min=10.7
 CFLAGS += -I/usr/local/opt/openal-soft/include
 else
-LDFLAGS += -Wl,-rpath=$(RPATH)
+ifndef NO_RPATH
+LDFLAGS += -Wl,-rpath=$(or $(RPATH),.)
+endif
 endif
 
 ifndef RELEASE


### PR DESCRIPTION
Simple QOL changes for packaging, it's nicer to disable things from the command line than having to `sed` the Makefile.