### PR TITLE
Bug Hunt addressing #1642

### DIFF
--- a/util.h
+++ b/util.h
@@ -1308,7 +1308,7 @@ class DirSet {
   DirSet();
   DirSet(const vector<Dir>&);
   DirSet(const initializer_list<Dir>&);
-  DirSet(bool n, bool s, bool e, bool w, bool ne, bool nw, bool se, bool sw);
+  DirSet(bool n, bool s, bool e, bool w, bool ne, bool nw, bool se, bool sw, bool ew, bool ns);
   typedef unsigned char ContentType;
   DirSet(ContentType);
   static DirSet fullSet();


### PR DESCRIPTION
Issue 1: Ground Terrain Border has field called extraBorder in the viewId. Atm it doesn't work on the adjacent tile if the tile is one of the disconnected north-south and disconnected east-west
- Fixed by adding Dirset bol value for ns (north-south connection) and ew (east-west connection).