### PR TITLE
Rename the crash report without deleting it

### DIFF
--- a/data_free/game_config/creatures.txt
+++ b/data_free/game_config/creatures.txt
@@ -503,7 +503,7 @@
     viewId = { "ghost" }
     attr = {
       DEFENSE 25
-      SPELL_DAMAGE 5 
+      SPELL_DAMAGE 5
     }
     permanentEffects = {
       FLYING 1
@@ -518,7 +518,7 @@
   {
     attr = {
       DEFENSE 25
-      SPELL_DAMAGE 5 
+      SPELL_DAMAGE 5
     }
     viewId = { "succubus" }
     body = {
@@ -1253,10 +1253,12 @@
     }
     hatedByEffect = HATE_DRAGONS
   }
-"WHITE_DRAGON" inherit "BLACK_DRAGON"
+"WHITE_DRAGON"
   {
     viewId = { "red_dragon" Rgb 240 240 240 255 }
-    attr = append {
+    attr = {
+      DAMAGE 45
+      DEFENSE 47
       COLD_DAMAGE 40
     }
     body = {
@@ -1295,7 +1297,7 @@
       { type = Glyph WEAPON ItemAttrBonus DAMAGE 3 chance = 0.3 }
       { type = Glyph RANGED_WEAPON ItemAttrBonus RANGED_DAMAGE 3 chance = 0.3 }
     }
-  }
+}
 "YELLOW_NAGA"
   {
     viewId = { "naga" Rgb 220 220 20 255 }
@@ -1325,7 +1327,7 @@
     }
     hatedByEffect = HATE_DRAGONS
   }
-"YELLOW_DRAGON" inherit "BLACK_DRAGON"
+"YELLOW_DRAGON" inherit "WHITE_DRAGON"
   {
     viewId = { "red_dragon" Rgb 240 200 0 255 }
     attr = append {

--- a/sendreport.bat
+++ b/sendreport.bat
@@ -9,5 +9,5 @@ if exist system_info.txt (
 )
 @type stacktrace.out >> report.txt
 curl.exe --progress-bar -F "userfile=@report.txt" blkrs.com/~michal/upload_stacktrace.php
-@del report.txt
+ren report.txt crashreport%time:~0,2%%time:~3,2%-%date:~-10,2%%date:~3,2%%date:~-4,4%.txt
 @del stacktrace.out


### PR DESCRIPTION
When Keeper produces a crash report, keep it on your local machine as well as uploading it (renamed as a time-stamped file). This lets modders help debug their own problems.