### PR TITLE
Fix Performance issue that causes ~300ms stutter every second

### DIFF
--- a/position_map.cpp
+++ b/position_map.cpp
@@ -29,29 +29,47 @@ static optional<const T&> getReferenceOptional(const heap_optional<T>& t) {
 template <class T>
 optional<const T&> PositionMap<T>::getReferenceMaybe(Position pos) const {
   LevelId levelId = pos.getLevel()->getUniqueId();
-  try {
-    const auto& table = tables.at(levelId);
-    if (pos.getCoord().inRectangle(table.getBounds()))
+
+  auto tableIter = tables.find(levelId);
+  if(tableIter != tables.end()) {
+    const auto& table = tableIter->second;
+
+    if(pos.getCoord().inRectangle(table.getBounds()))
       return getReferenceOptional(table[pos.getCoord()]);
-    else
-      return outliers.at(levelId).at(pos.getCoord());
-  } catch (std::out_of_range) {
-    return none;
+
+    auto outliersIter = outliers.find(levelId);
+    if(outliersIter != outliers.end()) {
+      const auto& outlier = outliersIter->second;
+      auto innerIter = outlier.find(pos.getCoord());
+      if(innerIter != outlier.end())
+        return innerIter->second;
+    }
   }
+
+    return none;
 }
 
 template <class T>
 optional<T&> PositionMap<T>::getReferenceMaybe(Position pos) {
   LevelId levelId = pos.getLevel()->getUniqueId();
-  try {
-    auto& table = tables.at(levelId);
-    if (pos.getCoord().inRectangle(table.getBounds()))
+
+  auto tableIter = tables.find(levelId);
+  if(tableIter != tables.end()) {
+    auto& table = tableIter->second;
+
+    if(pos.getCoord().inRectangle(table.getBounds()))
       return getReferenceOptional(table[pos.getCoord()]);
-    else
-      return outliers.at(levelId).at(pos.getCoord());
-  } catch (std::out_of_range) {
-    return none;
+
+    auto outliersIter = outliers.find(levelId);
+    if(outliersIter != outliers.end()) {
+      auto& outlier = outliersIter->second;
+      auto innerIter = outlier.find(pos.getCoord());
+      if(innerIter != outlier.end())
+        return innerIter->second;
+    }
   }
+
+  return none;
 }
 
 template<class T>


### PR DESCRIPTION
During a profiling run I noticed that one frame of every second takes about 300ms instead of the usual 1ms, which causes a very low average FPS and a noticable stutter, the larger the window is.
This was caused by a code snippet in map_gui.cpp: https://github.com/miki151/keeperrl/blob/8de51e8f1902043a24b8f8f191c2c984f6e075a8/map_gui.cpp#L1552-L1554

As can be seen, this is called exactly once every second. The actual performance problem lies in `PositionMap::getReferenceMaybe`, which heavily relies on exceptions when an entry is not found. This PR changes this code to rely on usual iterators instead of exceptions.

On my setup, this results in increasing the FPS from ~20 to over 100.