### PR TITLE
Fixed wrong y position of particles in ascii mode

### DIFF
--- a/fx_renderer.h
+++ b/fx_renderer.h
@@ -25,7 +25,7 @@ public:
   FXRenderer(const FXRenderer &) = delete;
   void operator=(const FXRenderer &) = delete;
 
-  void setView(float zoom, float offsetX, float offsetY, int w, int h);
+  void setView(float zoomX, float zoomY, float offsetX, float offsetY, int w, int h);
   void prepareOrdered();
 
   // TODO: span<> would be very useful
@@ -41,7 +41,8 @@ public:
 
   private:
   struct View {
-    float zoom;
+    float zoomX;
+    float zoomY;
     FVec2 offset;
     IVec2 size;
   };

--- a/fx_view_manager.cpp
+++ b/fx_view_manager.cpp
@@ -143,13 +143,14 @@ void FXViewManager::EntityInfo::updateFX(FXViewManager* manager, GenericId gid) 
     }
 }
 
-void FXViewManager::beginFrame(Renderer& renderer, float zoom, float ox, float oy) {
+void FXViewManager::beginFrame(Renderer& renderer, float zoomX, float zoomY, float ox, float oy) {
   for (auto& pair : *entities)
     pair.second.clearVisibility();
 
   auto size = renderer.getSize();
-  m_zoom = zoom;
-  fxRenderer->setView(zoom, ox, oy, size.x, size.y);
+  m_zoomX = zoomX;
+  m_zoomY = zoomY;
+  fxRenderer->setView(zoomX, zoomY, ox, oy, size.x, size.y);
   fxRenderer->prepareOrdered();
 }
 
@@ -212,8 +213,8 @@ void FXViewManager::drawFX(Renderer& renderer, GenericId id, Color color) {
 
   if (num > 0) {
     renderer.renderDeferredSprites();
-    float px = (entity.x) * Renderer::nominalSize * m_zoom;
-    float py = (entity.y) * Renderer::nominalSize * m_zoom;
+    float px = (entity.x) * Renderer::nominalSize * m_zoomX;
+    float py = (entity.y) * Renderer::nominalSize * m_zoomY;
     fxRenderer->drawOrdered(ids, num, px, py, color);
   }
 }

--- a/fx_view_manager.h
+++ b/fx_view_manager.h
@@ -24,7 +24,7 @@ class FXViewManager {
   FXViewManager(const FXViewManager&) = delete;
   void operator=(const FXViewManager&) = delete;
 
-  void beginFrame(Renderer&, float zoom, float ox, float oy);
+  void beginFrame(Renderer&, float zoomX, float zoomY, float ox, float oy);
   void finishFrame();
 
   void addEntity(GenericId, float x, float y);
@@ -52,5 +52,6 @@ class FXViewManager {
   std::unique_ptr<EntityMap> entities;
   fx::FXManager* fxManager = nullptr;
   fx::FXRenderer* fxRenderer = nullptr;
-  float m_zoom = 1.0f;
+  float m_zoomX = 1.0f;
+  float m_zoomY = 1.0f;
 };

--- a/map_gui.cpp
+++ b/map_gui.cpp
@@ -1196,9 +1196,10 @@ void MapGui::renderHighObjects(Renderer& renderer, Vec2 size, milliseconds curre
 void MapGui::renderMapObjects(Renderer& renderer, Vec2 size, milliseconds currentTimeReal) {
   PROFILE;
   if (fxViewManager) {
-    float zoom = float(layout->getSquareSize().x) / float(Renderer::nominalSize);
+    float zoomX = float(layout->getSquareSize().x) / float(Renderer::nominalSize);
+    float zoomY = float(layout->getSquareSize().y) / float(Renderer::nominalSize);
     auto offset = projectOnScreen(Vec2(0, 0));
-    fxViewManager->beginFrame(renderer, zoom, offset.x, offset.y);
+    fxViewManager->beginFrame(renderer, zoomX, zoomY, offset.x, offset.y);
   }
   renderAndInitFoW(renderer, size);
   if (spriteMode) {


### PR DESCRIPTION
When playing in ascii mode, particles (e.g. mining particles) are located in the wrong y-position because the FX code only considers the scaling factor on the x-axis. Since ascii mode has non-square tiles, this logic breaks.
This PR fixes this problem