### PR TITLE
fix unsafe string functions

### DIFF
--- a/miniunz.cpp
+++ b/miniunz.cpp
@@ -117,7 +117,7 @@ int makedir (
     return 0;
 
   buffer = (char*)malloc(len+1);
-  strcpy(buffer,newdir);
+  strlcpy(buffer,newdir,len+1);
 
   if (buffer[len-1] == '/') {
     buffer[len-1] = '\0';

--- a/steam_base.cpp
+++ b/steam_base.cpp
@@ -24,7 +24,7 @@ string formatError(int value, const pair<int, const char*>* strings, int count) 
     if (strings[n].first == value)
       return strings[n].second;
   char buffer[64];
-  sprintf(buffer, "unknown (%d)", value);
+  snprintf(buffer, sizeof(buffer), "unknown (%d)", value);
   return buffer;
 }
 


### PR DESCRIPTION
sprintf and and strcpy are vulnerable to buffer overflow. Replacing them with the safer snprintf and strlcpy is straightforward here. This still compiles and runs on OpenBSD, and should be transferable. I'm not sure if Linux will need `#include <bsd/string.h>` though...