### PR TITLE
Brainy spirits

### DIFF
--- a/creature_factory.cpp
+++ b/creature_factory.cpp
@@ -715,7 +715,7 @@ static vector<BuffId> getResistanceAndVulnerability(RandomGen& random) {
 }
 
 PCreature CreatureFactory::getSpecial(CreatureId id, TribeId tribe, SpecialParams p, const ControllerFactory& factory) {
-  Body body = Body(p.humanoid, p.living ? BodyMaterialId("FLESH") : BodyMaterialId("SPIRIT"),
+  Body body = Body(p.humanoid, p.living ? BodyMaterialId("FLESH") : BodyMaterialId("SPIRIT_WITH_BRAIN"),
       p.large ? Body::Size::LARGE : Body::Size::MEDIUM);
   if (p.wings)
     body.addWithoutUpdatingPermanentEffects(BodyPart::WING, 2);

--- a/data_free/game_config/creatures.txt
+++ b/data_free/game_config/creatures.txt
@@ -669,7 +669,7 @@ End
     }
     body = {
       type = NonHumanoid LARGE
-      material = SPIRIT
+      material = SPIRIT_WITH_BRAIN
     }
     permanentEffects = {
       CONSUMPTION_SKILL 1


### PR DESCRIPTION
The SPIRIT_WITH_BRAIN parameter you added for the Adoxie Adventurer is nifty.  I'm not certain if you meant for succubae, Legendary creatures, and doppelgangers to not get brains, but since Legendaries require C++ rather than being moddable, I figured I'd summon forth my arrogance and PR giving them SPIRIT_WITH_BRAIN, threw the doppelgangers in as well since they're generally combat units.

(Succubuses can't really kill anything, so brains would let them show up on Telepathy and benefit from Prophet Soup, but otherwise I'm not sure they'd need _WITH_BRAIN.)

If you mean for these creatures not to have brains, no problem, though I'd like to know that.

Thanks for your time and consideration.